### PR TITLE
Mobile-landscape v4: iPhone-landscape playable layout

### DIFF
--- a/index.html
+++ b/index.html
@@ -5,7 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <title>The Grey — board</title>
   <link href="https://fonts.googleapis.com/css2?family=Cormorant+Garamond:wght@400;600&family=Crimson+Text:wght@600&display=swap" rel="stylesheet">
-  <link rel="stylesheet" href="./styles.css?v=mlv4-20260508" />
+  <link rel="stylesheet" href="./styles.css?v=mlv4b-20260508" />
 </head>
 <body id="board" class="theme-dark parchment">
 
@@ -111,7 +111,7 @@
     </div>
   </div>
 
-  <script type="module" src="./index.js?v=mlv4-20260508"></script>
+  <script type="module" src="./index.js?v=mlv4b-20260508"></script>
 </body>
 
 </html>

--- a/styles.css
+++ b/styles.css
@@ -393,30 +393,35 @@ html,body{height:100%}
    ========================================================== */
 
 body.mobile-landscape{
-  /* Hand cards have their own size so they can be readable.
-     At 844px viewport: max 118px wide, scale ~0.79, ~13px body text. */
-  --hand-card-w: clamp(96px, 14vw, 118px);
-  --hand-card-h: calc(var(--hand-card-w) * 1.34);
+  /* Hand cards: legible-but-compact. Capping at 96px keeps the hand band
+     short enough that the board has 3 distinct rows of breathing room. */
+  --hand-card-w: clamp(78px, 11.5vw, 96px);
+  --hand-card-h: calc(var(--hand-card-w) * 1.32);
   --hand-card-scale: calc(var(--hand-card-w) / 150px);
 
-  /* Board cards (slots, flow) stay compact */
-  --card-w: clamp(54px, 11.2vw, 78px);
-  --card-h: calc(var(--card-w) * 1.34);
-  --card-radius: 10px;
+  /* Board cards (slot + flow) — heights set explicitly to match the
+     fixed grid rows below. We deliberately drop the 1.34 aspect ratio
+     so cards never overflow their row. */
+  --card-w: clamp(44px, 8vw, 56px);    /* slot card width */
+  --card-h: 56px;                       /* slot card height = slot row */
+  --flow-card-w: clamp(56px, 9.5vw, 72px);
+  --flow-card-h: 92px;                  /* fits flow row with price label */
+  --card-radius: 9px;
   --card-scale: calc(var(--card-w) / 150px);
   --slot-scale: calc(var(--card-scale) * .85);
 
   --gem-size: 22px;
   --card-gem: calc(20px * var(--card-scale));
 
-  --top-strip-h: 40px;
-  --hand-band-h: calc(var(--hand-card-h) + 22px);
+  --top-strip-h: 32px;
+  --hand-band-h: calc(var(--hand-card-h) + 14px);
 }
 
-/* Board grid: three equal rows between top-strip and hand band.
-   Desktop uses grid-template-rows:auto auto auto !important — must override. */
+/* Board grid: 56px slot rows + 1fr flow row.
+   For a 393px iPhone-landscape viewport this resolves to roughly:
+     32 (top) + 56 (AI) + ~96 (flow) + 56 (player) + 14 row-gaps + 142 (hand) ≈ 396 */
 body.mobile-landscape #board-grid.grid{
-  grid-template-rows: repeat(3, 1fr) !important;
+  grid-template-rows: 56px minmax(0, 1fr) 56px !important;
   row-gap: 4px !important;
   padding: var(--top-strip-h) 6px var(--hand-band-h) !important;
   height: 100vh;
@@ -424,11 +429,25 @@ body.mobile-landscape #board-grid.grid{
   box-sizing: border-box;
   align-content: stretch !important;
 }
+/* Clip each row so cards that exceed the row height don't bleed visually. */
+body.mobile-landscape .row.ai,
+body.mobile-landscape .row.flow,
+body.mobile-landscape .row.player{
+  overflow: hidden !important;
+  position: relative;
+  min-height: 0 !important;
+}
 
-/* ===== Portrait chips: top-left (player), top-right (AI) ===== */
+/* ===== Portrait chips: top-left (player), top-right (AI) =====
+   Desktop sets `.row.player .portrait { bottom: 16px }` — without
+   resetting it, position:fixed + top:4px + bottom:16px stretches the
+   chip across the whole viewport height. We explicitly null it. */
 body.mobile-landscape .row.player .portrait,
 body.mobile-landscape .row.ai .portrait{
-  position: fixed; top: 4px;
+  position: fixed !important;
+  top: 4px !important;
+  bottom: auto !important;
+  height: auto !important;
   display: flex; flex-direction: row; align-items: center; gap: 6px;
   z-index: 30;
   margin: 0; padding: 4px 8px;
@@ -437,8 +456,13 @@ body.mobile-landscape .row.ai .portrait{
   backdrop-filter: blur(4px);
   max-width: 38vw;
 }
-body.mobile-landscape .row.player .portrait{ left: 6px; }
-body.mobile-landscape .row.ai .portrait{ right: 6px; flex-direction: row-reverse; }
+body.mobile-landscape .row.player .portrait{
+  left: 6px !important; right: auto !important;
+}
+body.mobile-landscape .row.ai .portrait{
+  right: 6px !important; left: auto !important;
+  flex-direction: row-reverse;
+}
 
 body.mobile-landscape .portrait img{
   width: 28px; height: 28px; border-radius: 50%;
@@ -449,8 +473,27 @@ body.mobile-landscape .portrait figcaption{
   white-space: nowrap; overflow: hidden; text-overflow: ellipsis;
   max-width: 11vw; margin: 0;
 }
-body.mobile-landscape .hearts{ display: flex; gap: 2px; margin: 0; }
-body.mobile-landscape .hearts svg{ width: 12px; height: 12px; }
+body.mobile-landscape #player-hearts,
+body.mobile-landscape #ai-hearts{
+  display: flex !important;
+  gap: 1px !important;
+  margin: 0 !important;
+  max-width: 110px;
+  overflow: hidden;
+  flex-wrap: nowrap;
+}
+/* Hide empty heart slots in mobile-landscape — only show current HP. */
+body.mobile-landscape .hearts .heart-svg.empty{ display: none !important; }
+/* Force-shrink filled hearts. The SVG has width="36" attribute and a base
+   .hearts svg{36px} rule; we win on specificity (id+class+elem) and use
+   !important to override the inline attribute on Safari. */
+body.mobile-landscape #player-hearts svg,
+body.mobile-landscape #ai-hearts svg{
+  width: 12px !important;
+  height: 12px !important;
+}
+body.mobile-landscape #player-hearts .heart,
+body.mobile-landscape #ai-hearts .heart{ flex: 0 0 auto; line-height: 0; }
 body.mobile-landscape .aether-display{
   display: flex; gap: 4px; margin: 0; font-size: .7rem; align-items: center;
 }
@@ -498,6 +541,14 @@ body.mobile-landscape .slot{
   flex: 0 0 auto;
   box-shadow: inset 0 0 8px rgba(0,0,0,.45), 0 2px 8px rgba(0,0,0,.22);
 }
+/* Card placed inside a slot — fill the slot exactly so it doesn't push out */
+body.mobile-landscape .slot .card{
+  position: absolute !important;
+  inset: 0 !important;
+  width: 100% !important; height: 100% !important;
+  transform: none !important;
+  font-size: calc(1rem * var(--card-scale));
+}
 body.mobile-landscape .slot::after{ inset: 4px; border-radius: calc(var(--card-radius) - 3px); }
 body.mobile-landscape .slot .slot-title{ font-size: .55rem; line-height: 1; }
 body.mobile-landscape .slot.glyph .slot-title{ top: 6px; }
@@ -523,9 +574,18 @@ body.mobile-landscape #flow-row{
 }
 body.mobile-landscape #flow-row::-webkit-scrollbar{ display: none; }
 body.mobile-landscape .flow-card{
-  flex: 0 0 var(--card-w);
+  flex: 0 0 var(--flow-card-w);
+  width: var(--flow-card-w) !important;
+  height: var(--flow-card-h) !important;
   scroll-snap-align: center;
   position: relative;
+}
+/* Flow card content sized to fill the .flow-card box */
+body.mobile-landscape .flow-card > .card.market{
+  width: 100% !important;
+  height: 100% !important;
+  font-size: calc(1rem * (var(--flow-card-w) / 150px));
+  --card-scale: calc(var(--flow-card-w) / 150px);
 }
 body.mobile-landscape .price-label{
   bottom: -10px; font-size: .58rem;


### PR DESCRIPTION
Fast-forward of `v2.71` from `907a350` → `5bbd07a` (4 commits, no merge work needed). Targets iPhone landscape (~844×390).

## What you'll see when this deploys

- **Player chip parks in the top-left corner** — was being stretched the full viewport height because desktop's `.row.player .portrait { bottom: 16px }` leaked through `position:fixed; top:4px`. Reset `bottom`/`right`/`left`/`height` to `auto` with `!important`.
- **Hearts collapse cleanly** — only filled hearts show (12 max max-HP no longer bleeds across the screen), forced to 12px via id-level + `!important` (the JS-injected `#player-hearts` rule was beating my class selector), container capped at 110px with overflow clip.
- **Aether Flow stays in its row** — explicit grid `56px / 1fr / 56px` + `overflow:hidden` per row + separate `--flow-card-w/h` from `--card-w/h`. Slot cards fill 56px slot rows; flow cards live in the flexible middle band.
- **Hand strip upright + scrollable** — fan/rotation killed in mobile-landscape, `.hand` is a static flex container with snap, cards override `position`/`transform` to render upright. `layoutHand` clears `--tx/--ty/--rot` and exits in mobile-landscape so JS doesn't fight CSS.
- **Action menu → bottom sheet** — `showCardOptions` skips its inline left/top positioning in mobile-landscape; CSS pins `.action-pop` as a fixed bottom sheet with 44px+ touch targets.
- **HUD repositioned** — menu button collapses to hamburger top-center, deck/discard chips bottom-left of the hand band, end-turn FAB bottom-right.

## Touch fixes (rolled in earlier on this branch)

- `wireTouchDrag`: tap no longer creates a drag-ghost (drag only starts after 8px movement); dragging to a slot no longer also pops the action menu; the synthesized click after touchend doesn't double-fire `showCardOptions`.

## Detection + cache

- Detection switched to pure viewport (visualViewport short-side ≤ 500 && landscape). UA / `screen.*` were unreliable across iOS Safari quirks, "Request Desktop Site", and DevTools simulation.
- `body[data-mode]` breadcrumb (`mobile-landscape` / `mobile-portrait` / `desktop`) for in-DevTools confirmation.
- `styles.css` and `index.js` cache-busted via `?v=mlv4b-20260508` so reload picks up the fresh assets without a manual hard-refresh.

## Cleanup

- Removed orphaned `mobile.js`, `mobile.css`, `device-profile.js` — none of them were referenced from `index.html`.

## Commits in order

- `480a8a5` Fix mobile-landscape touch conflicts and tap-to-focus readability
- `6176fa4` Remove orphaned mobile.js, mobile.css, device-profile.js
- `acbc35e` Mobile-landscape v4 — iPhone-landscape playable rewrite
- `907a350` Mobile-landscape: viewport detection, cache-bust, HUD/menu refit *(already on v2.71)*
- `5bbd07a` Mobile-landscape: chip stretch fix, heart shrink, grid clamp *(this PR)*

Desktop layout is untouched — only `body.mobile-landscape` rules and the two `isMobileLandscape()` JS branches are scoped to mobile.

---
_Generated by [Claude Code](https://claude.ai/code/session_01C1TYVtozydzcqvzpY15HMA)_