### PR TITLE
Mobile-landscape: stop Aether Flow clipping

### DIFF
--- a/index.html
+++ b/index.html
@@ -5,7 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <title>The Grey — board</title>
   <link href="https://fonts.googleapis.com/css2?family=Cormorant+Garamond:wght@400;600&family=Crimson+Text:wght@600&display=swap" rel="stylesheet">
-  <link rel="stylesheet" href="./styles.css?v=mlv4b-20260508" />
+  <link rel="stylesheet" href="./styles.css?v=mlv4c-20260508" />
 </head>
 <body id="board" class="theme-dark parchment">
 
@@ -111,7 +111,7 @@
     </div>
   </div>
 
-  <script type="module" src="./index.js?v=mlv4b-20260508"></script>
+  <script type="module" src="./index.js?v=mlv4c-20260508"></script>
 </body>
 
 </html>

--- a/styles.css
+++ b/styles.css
@@ -555,14 +555,21 @@ body.mobile-landscape .slot.glyph .slot-title{ top: 6px; }
 body.mobile-landscape .slot.glyph .slot-rune{ opacity: .4; }
 body.mobile-landscape .slot.glyph .slot-rune svg{ width: 60%; height: 60%; }
 
-/* ===== Aether Flow: scrollable strip ===== */
+/* ===== Aether Flow: scrollable strip =====
+   Strip the desktop frame (border, background, big padding) and
+   the negative-offset price-label — both eat vertical space we
+   don't have between the slot bands. */
 body.mobile-landscape .flow-wrap{
   display: block; grid-template-columns: 1fr; width: 100%;
 }
 body.mobile-landscape .flow-board{
-  padding: 4px 6px 14px;
-  width: 100%; margin: 0;
-  border-radius: 8px;
+  padding: 0 4px !important;
+  width: 100% !important; margin: 0 !important;
+  border: none !important;
+  background: transparent !important;
+  box-shadow: none !important;
+  border-radius: 0 !important;
+  overflow: visible !important;
 }
 body.mobile-landscape #flow-row{
   display: flex !important;
@@ -570,7 +577,7 @@ body.mobile-landscape #flow-row{
   justify-content: center; align-items: center;
   overflow-x: auto; -webkit-overflow-scrolling: touch;
   scroll-snap-type: x mandatory; scrollbar-width: none;
-  padding-bottom: 4px;
+  padding: 0;
 }
 body.mobile-landscape #flow-row::-webkit-scrollbar{ display: none; }
 body.mobile-landscape .flow-card{
@@ -587,8 +594,18 @@ body.mobile-landscape .flow-card > .card.market{
   font-size: calc(1rem * (var(--flow-card-w) / 150px));
   --card-scale: calc(var(--flow-card-w) / 150px);
 }
+/* Price label as a small badge inside the card (top-left) so it
+   doesn't add to the wrapper's vertical extent */
 body.mobile-landscape .price-label{
-  bottom: -10px; font-size: .58rem;
+  position: absolute !important;
+  left: 4px !important; top: 4px !important;
+  bottom: auto !important; transform: none !important;
+  font-size: .55rem !important;
+  background: rgba(20,16,12,.85);
+  border: 1px solid #4a3d2f;
+  border-radius: 999px;
+  padding: 1px 6px;
+  z-index: 4;
 }
 
 /* ===== Hand: NO FAN, NO ROTATION — upright scrollable strip ===== */


### PR DESCRIPTION
Follow-up to PR #10. The Aether Flow row was clipping flow cards top and bottom — `.flow-board`'s desktop frame (padding + border + box-shadow + overflow:hidden) plus `.price-label { bottom: -10px }` together exceeded the ~97px the flow row gets between the 56px slot bands.

## Fixes

- **Strip the flow-board frame in mobile-landscape**: transparent background, no border, no shadow, no padding, `overflow: visible`. The board chrome is desktop-only.
- **Reposition `.price-label`** as a small absolute badge anchored top-left inside the card. The negative `bottom: -10px` offset pushed the label outside the wrapper, so the row's `overflow: hidden` chopped it off.

## Cache

- Bumped to `?v=mlv4c-20260508`.

Single commit `2d0c563`. Fast-forward, no conflicts.

---
_Generated by [Claude Code](https://claude.ai/code/session_01C1TYVtozydzcqvzpY15HMA)_