### PR TITLE
Mobile-landscape v8a: shrink .tl-wrap so the menu isn't a huge bar

### DIFF
--- a/index.html
+++ b/index.html
@@ -5,7 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <title>The Grey — board</title>
   <link href="https://fonts.googleapis.com/css2?family=Cormorant+Garamond:wght@400;600&family=Crimson+Text:wght@600&display=swap" rel="stylesheet">
-  <link rel="stylesheet" href="./styles.css?v=mlv8-20260508" />
+  <link rel="stylesheet" href="./styles.css?v=mlv8a-20260508" />
 </head>
 <body id="board" class="theme-dark parchment">
 
@@ -111,7 +111,7 @@
     </div>
   </div>
 
-  <script type="module" src="./index.js?v=mlv8-20260508"></script>
+  <script type="module" src="./index.js?v=mlv8a-20260508"></script>
 </body>
 
 </html>

--- a/styles.css
+++ b/styles.css
@@ -561,10 +561,16 @@ body.mobile-landscape .flow-title-rail { display: none !important; }
    pill — so it doesn't crowd the top-left where the player chip lives.
    The JS sets inline left:10px/top:10px on .tl-wrap; we override with
    !important to move it to the top-center between the two corner chips. */
+/* The .tl-wrap inherits width: min(34vw, 380px) from desktop, which on
+   landscape phone produces a ~317px-wide invisible container that
+   reads as a huge bar across the top. Force it to fit its content. */
 body.mobile-landscape .tl-wrap{
   left: 50% !important; right: auto !important;
   top: 4px !important;
   transform: translateX(-50%);
+  width: auto !important;
+  display: inline-flex !important;
+  gap: 0 !important;
 }
 body.mobile-landscape .menu-btn{
   padding: 6px 8px !important;


### PR DESCRIPTION
From your screenshot: there's a wide horizontal bar across the top center with just a hamburger icon in it. That bar isn't intentional — it's `.tl-wrap` (the menu wrapper) sitting at its **desktop width of `min(34vw, 380px)` ≈ 317px**, centered with `left:50% / translateX(-50%)`. Result: a 317px-wide invisible container reading as a giant strip across the top.

## Fix
Override `.tl-wrap` in mobile-landscape:
- `width: auto` so it hugs its content
- `display: inline-flex` + `gap: 0` so the layout collapses to just the hamburger button (~30px)

The menu now sits as a small pill at top-center between the two chip corners instead of stretching across a third of the viewport.

Cache-bust `?v=mlv8a-20260508`.

Single squashable commit `082d6cf`.

---
_Generated by [Claude Code](https://claude.ai/code/session_01C1TYVtozydzcqvzpY15HMA)_