### PR TITLE
Mobile-landscape v9: pull slot rows out of the grid

### DIFF
--- a/index.html
+++ b/index.html
@@ -5,7 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <title>The Grey — board</title>
   <link href="https://fonts.googleapis.com/css2?family=Cormorant+Garamond:wght@400;600&family=Crimson+Text:wght@600&display=swap" rel="stylesheet">
-  <link rel="stylesheet" href="./styles.css?v=mlv8a-20260508" />
+  <link rel="stylesheet" href="./styles.css?v=mlv9-20260508" />
 </head>
 <body id="board" class="theme-dark parchment">
 
@@ -111,7 +111,7 @@
     </div>
   </div>
 
-  <script type="module" src="./index.js?v=mlv8a-20260508"></script>
+  <script type="module" src="./index.js?v=mlv9-20260508"></script>
 </body>
 
 </html>

--- a/styles.css
+++ b/styles.css
@@ -400,13 +400,13 @@ body.mobile-landscape{
   --hand-card-h: calc(var(--hand-card-w) * 1.32);
   --hand-card-scale: calc(var(--hand-card-w) / 150px);
 
-  /* Slot tiles fit a 40px row; flow cards sized to fit the 1fr zone
-     after fixed budgets are subtracted on a 430px iPhone-Plus
-     landscape (60 HUD + 40 + 40 + 144 hand + gaps = 288 -> 142 flow). */
-  --card-w: clamp(40px, 7.0vw, 50px);
-  --card-h: 38px;
-  --flow-card-w: clamp(68px, 10.8vw, 88px);
-  --flow-card-h: 130px;
+  /* Slot tiles pinned in corners below each chip (small but readable).
+     Flow cards bumped taller now that the grid isn't carrying slot
+     rows — there's room for full rules text without clipping. */
+  --card-w: 40px;
+  --card-h: 50px;
+  --flow-card-w: clamp(72px, 11.2vw, 92px);
+  --flow-card-h: 156px;
   --card-radius: 9px;
   --card-scale: calc(var(--card-w) / 150px);
   --slot-scale: calc(var(--card-scale) * .85);
@@ -414,38 +414,40 @@ body.mobile-landscape{
   --gem-size: 22px;
   --card-gem: calc(20px * var(--card-scale));
 
-  --top-strip-h: 60px;                    /* avatar pill (38) + sub-strip (~18) */
+  --top-strip-h: 110px;                   /* chip 38 + sub-strip 18 + slot row 50 + gaps */
   --hand-band-h: calc(var(--hand-card-h) + 12px);
 }
 
-/* Board grid: thinner slot rows + bigger flow row (the stage).
-   On 430px landscape: 60 (top HUD) + 44 (AI slots) + ~158 (flow)
-   + 44 (player slots) + ~8 gaps + 132 (hand) ≈ 446 — flow row
-   gets minmax(0, 1fr) so it expands to fill any remainder. */
+/* Board grid: slot rows collapsed to 0; flow takes the whole 1fr.
+   Slots themselves are pulled out of the grid and pinned in the
+   top corners below each chip — see the #ai-slots / #player-slots
+   rules further down. The grid only houses the flow row now. */
 body.mobile-landscape #board-grid.grid{
-  grid-template-rows: 40px minmax(0, 1fr) 40px !important;
-  row-gap: 2px !important;
+  grid-template-rows: 0 minmax(0, 1fr) 0 !important;
+  row-gap: 0 !important;
   padding: var(--top-strip-h) 6px var(--hand-band-h) !important;
   height: 100vh;
   height: 100dvh;
   box-sizing: border-box;
   align-content: stretch !important;
 }
-/* Clip slot rows so anything taller doesn't visually overflow.
-   The flow row keeps overflow:visible so the buyable-pulse halo
-   on cards isn't clipped at the row edges. */
+/* Slot rows collapsed: zero height with overflow visible so the
+   #ai-mini child (absolutely positioned within .row.ai) still
+   renders. We re-pin the slots themselves with position:fixed
+   so they're not affected by the row collapse. */
 body.mobile-landscape .row.ai,
 body.mobile-landscape .row.player{
-  overflow: hidden !important;
-  position: relative;
+  height: 0 !important;
   min-height: 0 !important;
+  overflow: visible !important;
+  position: relative;
 }
 body.mobile-landscape .row.flow{
   overflow: visible !important;
   position: relative;
   min-height: 0 !important;
   /* Subtle warm radial backdrop so the market reads as the focal
-     stage, distinct from the slot rows above and below. */
+     stage. */
   background:
     radial-gradient(ellipse at center,
       rgba(198,165,106,.08) 0%,
@@ -580,13 +582,28 @@ body.mobile-landscape .menu-btn{
 body.mobile-landscape .menu-btn .lbl,
 body.mobile-landscape .menu-btn .ver{ display: none !important; }
 
-/* ===== Slot rows ===== */
+/* ===== Slot rows: pinned in the corners below each chip =====
+   Out of the grid flow entirely. Each slot row is 4 small tiles
+   horizontal, 40 wide × 50 tall = ~172 wide total. Player on the
+   left below the player chip; AI on the right below the AI chip. */
 body.mobile-landscape #ai-slots.slot-row,
 body.mobile-landscape #player-slots.slot-row{
+  position: fixed !important;
+  top: 60px !important;          /* below chip (38) + sub-strip (~18) + 4 gap */
   display: flex !important; flex-direction: row;
-  gap: 6px !important;
-  width: 100%; max-width: 100%;
-  justify-content: center; align-items: center;
+  gap: 4px !important;
+  width: auto !important; max-width: none !important;
+  justify-content: flex-start; align-items: center;
+  z-index: 25;
+  margin: 0;
+  padding: 0;
+}
+body.mobile-landscape #player-slots.slot-row{
+  left: 6px !important; right: auto !important;
+}
+body.mobile-landscape #ai-slots.slot-row{
+  right: 6px !important; left: auto !important;
+  flex-direction: row-reverse;    /* glyph slot ends up on the outer (right) edge */
 }
 /* Empty slot: nearly-invisible dashed outline, no fill, no shadow.
    The slot doesn't compete with the flow row when there's no card
@@ -820,19 +837,22 @@ body.mobile-landscape #weaver-backdrop img{
   filter: saturate(.7) brightness(.7);
 }
 
-/* AI mini hand — small strip in the right margin of the AI slot row.
-   The slot row uses justify-content:center, so the right-hand area
-   is empty space we can occupy. */
+/* AI mini hand — pinned to viewport (the .row.ai parent is height:0
+   so absolute positioning is off the table). Sits to the left of
+   the AI slot row in the top-right corner. */
 body.mobile-landscape #ai-mini{
   display: flex !important;
-  position: absolute !important;
-  top: 50%; right: 6px;
+  position: fixed !important;
+  top: 60px;
+  right: calc(6px + 172px + 8px);  /* AI slot row width + gap */
   left: auto !important;
-  transform: translateY(-50%) !important;
+  bottom: auto !important;
+  transform: none !important;
   width: auto !important;
   flex-direction: row;
+  align-items: center;
   gap: 4px;
-  z-index: 8;
+  z-index: 25;
   pointer-events: none;
 }
 body.mobile-landscape .ai-mini-hand{


### PR DESCRIPTION
## Diagnosis from latest screenshot

Flow cards were overlapping the player slot row — the flow zone got ~142px, the cards were 130px tall, and there wasn't enough breathing room. Plus the slot rows themselves still consumed 80px (40 + 40) of vertical space the user wants reclaimed.

## Restructure: slot rows out of the grid

- `grid-template-rows: 40px 1fr 40px` → **`0 1fr 0`**. Slot rows still exist as DOM nodes (the AI mini hand lives inside `.row.ai`) but collapse to zero height with `overflow: visible`.
- `#ai-slots` / `#player-slots` are now **`position: fixed`** in the top corners below the chip + sub-strip:
  - `top: 60px` (chip 38 + sub-strip 18 + 4 gap)
  - `left: 6` for player, `right: 6` for AI
  - 4 small tiles (40 wide × 50 tall) horizontal; AI uses `flex-direction: row-reverse` so the glyph slot ends up on the outer edge
- `#ai-mini` repositioned to `position: fixed` at `top: 60px, right: calc(6 + 172 + 8)` — sits just left of the AI slot row.

## Bigger flow cards

| Var | Before | After |
|---|---|---|
| `--flow-card-w` clamp | 68–88 | **72–92** |
| `--flow-card-h` | 130 | **156** |

## Sizing math (430px viewport)

`--top-strip-h: 60 → 110` (chip 38 + sub-strip 18 + slot row 50 + gaps).

Fixed: 110 (HUD column) + 144 (hand) = **254** → flow gets **176px** for 156-tall flow cards (20px breathing).

Cache-bust `?v=mlv9-20260508`.

Single squashable commit `9bfbcee`.

---
_Generated by [Claude Code](https://claude.ai/code/session_01C1TYVtozydzcqvzpY15HMA)_