### PR TITLE
Mobile-landscape v10: restore hand fan, partial revert v9, shrink flow

### DIFF
--- a/index.html
+++ b/index.html
@@ -5,7 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <title>The Grey — board</title>
   <link href="https://fonts.googleapis.com/css2?family=Cormorant+Garamond:wght@400;600&family=Crimson+Text:wght@600&display=swap" rel="stylesheet">
-  <link rel="stylesheet" href="./styles.css?v=mlv9-20260508" />
+  <link rel="stylesheet" href="./styles.css?v=mlv10-20260508" />
 </head>
 <body id="board" class="theme-dark parchment">
 
@@ -111,7 +111,7 @@
     </div>
   </div>
 
-  <script type="module" src="./index.js?v=mlv9-20260508"></script>
+  <script type="module" src="./index.js?v=mlv10-20260508"></script>
 </body>
 
 </html>

--- a/index.js
+++ b/index.js
@@ -1998,28 +1998,20 @@ function isMobileLandscape(){
 function layoutHand(container, cards) {
   const N = cards.length; if (!N || !container) return;
 
-  // Mobile-landscape uses a CSS-driven flex strip — no fan, no rotation,
-  // no absolute positioning. Clear any leftover desktop-fan custom props
-  // so cards render where CSS puts them.
-  if (isMobileLandscape()){
-    cards.forEach((el, i) => {
-      el.style.removeProperty("--tx");
-      el.style.removeProperty("--ty");
-      el.style.removeProperty("--rot");
-      el.style.zIndex = String(400 + i);
-    });
-    return;
-  }
-
-  const MAX_ANGLE = 22;
-  const MIN_ANGLE = 8;
+  // Mobile-landscape uses a tighter fan than desktop (smaller angles
+  // and lift) so cards stay readable in the limited landscape band.
+  const isML = isMobileLandscape();
+  const MAX_ANGLE = isML ? 14 : 22;
+  const MIN_ANGLE = isML ? 4  : 8;
   const totalAngle = N===1 ? 0 : clamp(MIN_ANGLE + (N-2)*2, MIN_ANGLE, MAX_ANGLE);
   const stepA  = N===1 ? 0 : totalAngle/(N-1);
   const startA = -totalAngle/2;
   const cw = cards[0]?.clientWidth || container.clientWidth / Math.max(1, N);
-  const stepX = cw * 0.98;
+  // Tighter overlap on mobile (.78) so wider hands fit without
+  // running off the edges; desktop kept at .98.
+  const stepX = cw * (isML ? 0.78 : 0.98);
   const startX = -stepX * (N-1) / 2;
-  const LIFT = 44;
+  const LIFT = isML ? 14 : 44;
 
   cards.forEach((el,i)=>{
     const a = startA + stepA*i;

--- a/styles.css
+++ b/styles.css
@@ -400,13 +400,12 @@ body.mobile-landscape{
   --hand-card-h: calc(var(--hand-card-w) * 1.32);
   --hand-card-scale: calc(var(--hand-card-w) / 150px);
 
-  /* Slot tiles pinned in corners below each chip (small but readable).
-     Flow cards bumped taller now that the grid isn't carrying slot
-     rows — there's room for full rules text without clipping. */
-  --card-w: 40px;
-  --card-h: 50px;
-  --flow-card-w: clamp(72px, 11.2vw, 92px);
-  --flow-card-h: 156px;
+  /* Slot tiles fit a 36px row; flow cards modest height so the flow
+     row stops dominating (user feedback). */
+  --card-w: clamp(38px, 6.6vw, 48px);
+  --card-h: 34px;
+  --flow-card-w: clamp(68px, 10.6vw, 86px);
+  --flow-card-h: 132px;
   --card-radius: 9px;
   --card-scale: calc(var(--card-w) / 150px);
   --slot-scale: calc(var(--card-scale) * .85);
@@ -414,40 +413,33 @@ body.mobile-landscape{
   --gem-size: 22px;
   --card-gem: calc(20px * var(--card-scale));
 
-  --top-strip-h: 110px;                   /* chip 38 + sub-strip 18 + slot row 50 + gaps */
-  --hand-band-h: calc(var(--hand-card-h) + 12px);
+  --top-strip-h: 60px;                    /* chip 38 + sub-strip ~18 (slot row is in the grid below) */
+  --hand-band-h: calc(var(--hand-card-h) + 16px);  /* extra room for the fan's vertical lift */
 }
 
-/* Board grid: slot rows collapsed to 0; flow takes the whole 1fr.
-   Slots themselves are pulled out of the grid and pinned in the
-   top corners below each chip — see the #ai-slots / #player-slots
-   rules further down. The grid only houses the flow row now. */
+/* Board grid: thin slot rows (36) + 1fr flow. v9's "slot rows out of
+   the grid into corners" experiment broke the AI mini hand and made
+   the flow row take too much space; reverted. */
 body.mobile-landscape #board-grid.grid{
-  grid-template-rows: 0 minmax(0, 1fr) 0 !important;
-  row-gap: 0 !important;
+  grid-template-rows: 36px minmax(0, 1fr) 36px !important;
+  row-gap: 2px !important;
   padding: var(--top-strip-h) 6px var(--hand-band-h) !important;
   height: 100vh;
   height: 100dvh;
   box-sizing: border-box;
   align-content: stretch !important;
 }
-/* Slot rows collapsed: zero height with overflow visible so the
-   #ai-mini child (absolutely positioned within .row.ai) still
-   renders. We re-pin the slots themselves with position:fixed
-   so they're not affected by the row collapse. */
 body.mobile-landscape .row.ai,
 body.mobile-landscape .row.player{
-  height: 0 !important;
+  height: auto !important;
   min-height: 0 !important;
-  overflow: visible !important;
+  overflow: hidden !important;
   position: relative;
 }
 body.mobile-landscape .row.flow{
   overflow: visible !important;
   position: relative;
   min-height: 0 !important;
-  /* Subtle warm radial backdrop so the market reads as the focal
-     stage. */
   background:
     radial-gradient(ellipse at center,
       rgba(198,165,106,.08) 0%,
@@ -482,7 +474,7 @@ body.mobile-landscape .row.ai .portrait{
   text-shadow: 0 1px 2px rgba(0,0,0,.85);
 }
 body.mobile-landscape .row.player .portrait{
-  left: 6px !important; right: auto !important;
+  left: 42px !important; right: auto !important;     /* clear the top-left hamburger (~30px wide + gap) */
   flex-direction: row;
   text-align: left;
   justify-content: flex-start;
@@ -563,13 +555,14 @@ body.mobile-landscape .flow-title-rail { display: none !important; }
    pill — so it doesn't crowd the top-left where the player chip lives.
    The JS sets inline left:10px/top:10px on .tl-wrap; we override with
    !important to move it to the top-center between the two corner chips. */
-/* The .tl-wrap inherits width: min(34vw, 380px) from desktop, which on
-   landscape phone produces a ~317px-wide invisible container that
-   reads as a huge bar across the top. Force it to fit its content. */
+/* Menu button: small icon pinned to the very top-left corner of the
+   viewport, ABOVE the player chip's avatar so the chip can sit
+   slightly to its right. The chip's left:6 is shifted to left:42 in
+   the chip rules below. */
 body.mobile-landscape .tl-wrap{
-  left: 50% !important; right: auto !important;
+  left: 6px !important; right: auto !important;
   top: 4px !important;
-  transform: translateX(-50%);
+  transform: none !important;
   width: auto !important;
   display: inline-flex !important;
   gap: 0 !important;
@@ -582,28 +575,14 @@ body.mobile-landscape .menu-btn{
 body.mobile-landscape .menu-btn .lbl,
 body.mobile-landscape .menu-btn .ver{ display: none !important; }
 
-/* ===== Slot rows: pinned in the corners below each chip =====
-   Out of the grid flow entirely. Each slot row is 4 small tiles
-   horizontal, 40 wide × 50 tall = ~172 wide total. Player on the
-   left below the player chip; AI on the right below the AI chip. */
+/* ===== Slot rows: back in grid as flex-centered horizontal strips ===== */
 body.mobile-landscape #ai-slots.slot-row,
 body.mobile-landscape #player-slots.slot-row{
-  position: fixed !important;
-  top: 60px !important;          /* below chip (38) + sub-strip (~18) + 4 gap */
   display: flex !important; flex-direction: row;
-  gap: 4px !important;
-  width: auto !important; max-width: none !important;
-  justify-content: flex-start; align-items: center;
-  z-index: 25;
-  margin: 0;
-  padding: 0;
-}
-body.mobile-landscape #player-slots.slot-row{
-  left: 6px !important; right: auto !important;
-}
-body.mobile-landscape #ai-slots.slot-row{
-  right: 6px !important; left: auto !important;
-  flex-direction: row-reverse;    /* glyph slot ends up on the outer (right) edge */
+  gap: 6px !important;
+  width: 100%; max-width: 100%;
+  justify-content: center; align-items: center;
+  position: static !important;
 }
 /* Empty slot: nearly-invisible dashed outline, no fill, no shadow.
    The slot doesn't compete with the flow row when there's no card
@@ -837,22 +816,20 @@ body.mobile-landscape #weaver-backdrop img{
   filter: saturate(.7) brightness(.7);
 }
 
-/* AI mini hand — pinned to viewport (the .row.ai parent is height:0
-   so absolute positioning is off the table). Sits to the left of
-   the AI slot row in the top-right corner. */
+/* AI mini hand — small strip in the right margin of the AI slot row.
+   The slot row uses justify-content:center so the right side of the
+   row has free space we can occupy. */
 body.mobile-landscape #ai-mini{
   display: flex !important;
-  position: fixed !important;
-  top: 60px;
-  right: calc(6px + 172px + 8px);  /* AI slot row width + gap */
+  position: absolute !important;
+  top: 50%; right: 6px;
   left: auto !important;
-  bottom: auto !important;
-  transform: none !important;
+  transform: translateY(-50%) !important;
   width: auto !important;
   flex-direction: row;
   align-items: center;
   gap: 4px;
-  z-index: 25;
+  z-index: 8;
   pointer-events: none;
 }
 body.mobile-landscape .ai-mini-hand{
@@ -873,7 +850,7 @@ body.mobile-landscape .ai-mini-piles .mini-pile::after{
   right: -4px; bottom: -4px;
 }
 
-/* ===== Hand: NO FAN, NO ROTATION — upright scrollable strip ===== */
+/* ===== Hand: MTGA-style fan ===== */
 body.mobile-landscape .hand-wrap{
   position: fixed; left: 0; right: 0; bottom: 0;
   height: var(--hand-band-h);
@@ -881,45 +858,50 @@ body.mobile-landscape .hand-wrap{
   background: linear-gradient(to top, rgba(15,12,9,.92) 60%, rgba(15,12,9,0));
   padding: 6px 8px calc(8px + env(safe-area-inset-bottom, 0px));
   box-sizing: border-box;
+  pointer-events: none;
 }
+/* Centered fan container — matches desktop semantics so the JS
+   layoutHand fan transform (translate(--tx,--ty) rotate(--rot))
+   works the same way it does on desktop. */
 body.mobile-landscape .hand{
-  position: static;
-  display: flex; flex-direction: row; align-items: center;
-  gap: 8px;
-  width: 100%; height: 100%;
-  transform: none; perspective: none;
-  overflow-x: auto; -webkit-overflow-scrolling: touch;
-  scroll-snap-type: x mandatory; scrollbar-width: none;
-  /* leave room for the bottom-left HUD chips and bottom-right End-turn FAB */
-  padding: 0 80px 4px 110px;
+  position: absolute;
+  left: 50%; bottom: 0;
+  transform: translateX(-50%);
+  width: 100%; max-width: 100vw;
+  height: var(--hand-band-h);
+  perspective: 1200px;
+  pointer-events: auto;
+  display: block;
+  overflow: visible;
 }
-body.mobile-landscape .hand::-webkit-scrollbar{ display: none; }
 
-/* override the absolute fan positioning of cards in the hand. Use
-   !important on width/height because the desktop .card rule sets
-   them to var(--card-w/h) and we need to be sure hand cards don't
-   pick those up. */
+/* Cards: keep desktop's absolute + fan transform. We still need
+   to size them to the mobile clamp and unset the desktop's card-w
+   so they don't render at slot-tile size. */
 body.mobile-landscape .hand .card{
-  position: relative !important;
-  top: auto !important; left: auto !important;
+  position: absolute !important;
+  top: auto !important;
+  bottom: 0 !important;
+  left: 50% !important;
   width: var(--hand-card-w) !important;
   height: var(--hand-card-h) !important;
   max-height: var(--hand-card-h) !important;
-  flex: 0 0 var(--hand-card-w) !important;
   font-size: calc(1rem * var(--hand-card-scale));
   --card-scale: var(--hand-card-scale);
   --card-gem: calc(22px * var(--hand-card-scale));
-  transform: none !important;
   transform-origin: 50% 100%;
-  scroll-snap-align: center;
   border-radius: 10px;
   box-shadow: 0 6px 12px rgba(0,0,0,.45);
-  transition: transform .14s ease-out, box-shadow .14s ease-out;
+  transition: transform .18s ease, box-shadow .14s ease-out;
   overflow: hidden;
 }
-body.mobile-landscape .hand .card:hover,
+/* Tap-focus lift: compose with the fan transform so the card stays
+   rotated as part of the fan but rises a bit. */
 body.mobile-landscape .hand .card.is-focus{
-  transform: translateY(-6px) scale(1.04) !important;
+  transform:
+    translate(var(--tx,0), calc(var(--ty,0px) - 14px))
+    rotate(var(--rot,0deg))
+    scale(1.06) !important;
   box-shadow: 0 14px 24px rgba(0,0,0,.6);
   z-index: 50 !important;
 }


### PR DESCRIPTION
## User feedback addressed

1. **Hamburger position weird** — moved from top-center to top-left corner. Player chip shifts to `left: 42px` to clear it.
2. **Hand should fan like MTGA** — restored. `layoutHand()` no longer skips the fan on mobile; uses tuned params (`MAX_ANGLE 14`, `LIFT 14`, `stepX cw*0.78`).
3. **Aetherflow row too big** — `--flow-card-h 156 → 132`, `--flow-card-w clamp(72..92) → (68..86)`.
4. **AI cards not showing** — root cause was v9's `height: 0` on `.row.ai` killing absolute positioning of `#ai-mini`. Reverted: AI mini hand is back to `top: 50%, right: 6` inside `.row.ai`.
5. **Some cards cut off** — slot rows back in the grid, hand cards re-sized to fit, math reworked.

## Partial revert of v9

The "slot rows out of the grid into corners" experiment didn't pay off — it broke the AI mini hand and didn't visually solve anything. Reverted:
- Slot rows back in the grid as thin 36px rows.
- `#ai-slots` / `#player-slots` back to flex-centered horizontal strips.
- `.row.ai` / `.row.player` back to normal grid items with `overflow: hidden`.
- `--top-strip-h: 110 → 60`.

## Hand fan technical change

- `index.js:layoutHand()` removed the early-return for mobile and computes mobile-specific fan params.
- CSS: dropped the `transform:none / position:relative` overrides on `.hand .card`. Cards are back to `position:absolute` and the desktop fan transform `translate(--tx,--ty) rotate(--rot)` applies — just with tighter mobile values.
- `.hand` becomes a centered fan container (`left:50%; transform:translateX(-50%)`).
- Hover-lift updated to compose with the fan transform instead of replacing it.

## Sizing math on 430px landscape

`60 (HUD) + 36 (AI slots) + 36 (player slots) + 148 (hand band: 132 card + 16 fan buffer) + 4 (row-gaps) = 284 fixed`. Flow gets **146px** for 132-tall flow cards (14px breathing).

Cache-bust `?v=mlv10-20260508`.

Single squashable commit `c3fb304`.

---
_Generated by [Claude Code](https://claude.ai/code/session_01C1TYVtozydzcqvzpY15HMA)_