### PR TITLE
Mobile-landscape v10a: stop flow cards bleeding into slot rows

### DIFF
--- a/index.html
+++ b/index.html
@@ -5,7 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <title>The Grey — board</title>
   <link href="https://fonts.googleapis.com/css2?family=Cormorant+Garamond:wght@400;600&family=Crimson+Text:wght@600&display=swap" rel="stylesheet">
-  <link rel="stylesheet" href="./styles.css?v=mlv10-20260508" />
+  <link rel="stylesheet" href="./styles.css?v=mlv10a-20260508" />
 </head>
 <body id="board" class="theme-dark parchment">
 
@@ -111,7 +111,7 @@
     </div>
   </div>
 
-  <script type="module" src="./index.js?v=mlv10-20260508"></script>
+  <script type="module" src="./index.js?v=mlv10a-20260508"></script>
 </body>
 
 </html>

--- a/styles.css
+++ b/styles.css
@@ -400,12 +400,13 @@ body.mobile-landscape{
   --hand-card-h: calc(var(--hand-card-w) * 1.32);
   --hand-card-scale: calc(var(--hand-card-w) / 150px);
 
-  /* Slot tiles fit a 36px row; flow cards modest height so the flow
-     row stops dominating (user feedback). */
-  --card-w: clamp(38px, 6.6vw, 48px);
-  --card-h: 34px;
-  --flow-card-w: clamp(68px, 10.6vw, 86px);
-  --flow-card-h: 132px;
+  /* Slot tiles fit a 44px row; flow cards capped by the 1fr zone
+     available height so they don't bleed into the slot rows on
+     shorter landscape phones. */
+  --card-w: clamp(40px, 7.0vw, 50px);
+  --card-h: 40px;
+  --flow-card-w: clamp(64px, 10vw, 82px);
+  --flow-card-h: min(122px, calc(100dvh - 308px));
   --card-radius: 9px;
   --card-scale: calc(var(--card-w) / 150px);
   --slot-scale: calc(var(--card-scale) * .85);
@@ -417,11 +418,10 @@ body.mobile-landscape{
   --hand-band-h: calc(var(--hand-card-h) + 16px);  /* extra room for the fan's vertical lift */
 }
 
-/* Board grid: thin slot rows (36) + 1fr flow. v9's "slot rows out of
-   the grid into corners" experiment broke the AI mini hand and made
-   the flow row take too much space; reverted. */
+/* Board grid: 44px slot rows (taller so the dashed outlines render
+   visibly, no longer compressed) + 1fr flow. */
 body.mobile-landscape #board-grid.grid{
-  grid-template-rows: 36px minmax(0, 1fr) 36px !important;
+  grid-template-rows: 44px minmax(0, 1fr) 44px !important;
   row-gap: 2px !important;
   padding: var(--top-strip-h) 6px var(--hand-band-h) !important;
   height: 100vh;
@@ -437,9 +437,15 @@ body.mobile-landscape .row.player{
   position: relative;
 }
 body.mobile-landscape .row.flow{
-  overflow: visible !important;
+  /* Clip flow cards to their row so they can't bleed into the slot
+     rows above/below. Pulse halos may get clipped slightly but the
+     readability win is worth it. */
+  overflow: hidden !important;
   position: relative;
   min-height: 0 !important;
+  display: flex !important;
+  align-items: center;
+  justify-content: center;
   background:
     radial-gradient(ellipse at center,
       rgba(198,165,106,.08) 0%,


### PR DESCRIPTION
## Diagnosis

From the screenshot the slot rows were rendering but invisibly thin / bleeding behind the flow cards because:
- Slot rows were only 36px with 34px slot tiles → barely any visible footprint for the dashed outlines.
- `.row.flow` had `overflow: visible` (to preserve the buyable-pulse halo), so flow cards could extend past the row bounds and visually cover the slot rows above/below.
- On shorter viewports the 1fr flow zone shrank below the card height — flow cards overflowed by design into the slot rows.

## Fixes

1. **Bigger slot rows**: `36 → 44px`; `--card-h 34 → 40`. Dashed outlines now have real visible footprint.
2. **Clip flow row**: `.row.flow { overflow: hidden; display: flex; align-items: center; justify-content: center }`. Flow cards can no longer bleed past the row bounds. Buyable pulse halo will get clipped at row edges but the readability win is worth it.
3. **Responsive flow card height**: `--flow-card-h: min(122px, calc(100dvh - 308px))`. On 430px viewport it caps at 122; on a 380px viewport it resolves to ~72 so cards stay inside the smaller flow zone.

## Sizing math (430px viewport)

`60 (HUD) + 44 (AI slots) + 2 + 1fr + 2 + 44 (player slots) + 148 (hand band) = 300 fixed → 130 flow → 122-tall flow cards (8px breathing).`

Cache-bust `?v=mlv10a-20260508`.

Single squashable commit `74782dc`.

---
_Generated by [Claude Code](https://claude.ai/code/session_01C1TYVtozydzcqvzpY15HMA)_