### PR TITLE
Mobile-landscape v11: shrink hand, grow field

### DIFF
--- a/index.html
+++ b/index.html
@@ -5,7 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <title>The Grey — board</title>
   <link href="https://fonts.googleapis.com/css2?family=Cormorant+Garamond:wght@400;600&family=Crimson+Text:wght@600&display=swap" rel="stylesheet">
-  <link rel="stylesheet" href="./styles.css?v=mlv10a-20260508" />
+  <link rel="stylesheet" href="./styles.css?v=mlv11-20260508" />
 </head>
 <body id="board" class="theme-dark parchment">
 
@@ -111,7 +111,7 @@
     </div>
   </div>
 
-  <script type="module" src="./index.js?v=mlv10a-20260508"></script>
+  <script type="module" src="./index.js?v=mlv11-20260508"></script>
 </body>
 
 </html>

--- a/styles.css
+++ b/styles.css
@@ -393,20 +393,19 @@ html,body{height:100%}
    ========================================================== */
 
 body.mobile-landscape{
-  /* Hand cards: significantly bigger so they read like real cards
-     and the hand feels prominent (Slay the Spire / MTG Arena vibe).
-     Cap matches a 132px-tall card that fills the band cleanly. */
-  --hand-card-w: clamp(80px, 11vw, 100px);
+  /* Hand cards: smaller — the hand is inventory, not the focal point.
+     Was clamp(80,11vw,100); shrunk so the hand band is ~110 instead
+     of ~148, freeing 38 vertical pixels for the field. */
+  --hand-card-w: clamp(60px, 8.4vw, 75px);
   --hand-card-h: calc(var(--hand-card-w) * 1.32);
   --hand-card-scale: calc(var(--hand-card-w) / 150px);
 
-  /* Slot tiles fit a 44px row; flow cards capped by the 1fr zone
-     available height so they don't bleed into the slot rows on
-     shorter landscape phones. */
-  --card-w: clamp(40px, 7.0vw, 50px);
-  --card-h: 40px;
-  --flow-card-w: clamp(64px, 10vw, 82px);
-  --flow-card-h: min(122px, calc(100dvh - 308px));
+  /* Slot tiles bigger so placed cards are actually readable;
+     slot rows 44 -> 48. Flow cards bigger and more breathing. */
+  --card-w: clamp(44px, 7.6vw, 56px);
+  --card-h: 44px;
+  --flow-card-w: clamp(70px, 11vw, 90px);
+  --flow-card-h: min(144px, calc(100dvh - 270px));
   --card-radius: 9px;
   --card-scale: calc(var(--card-w) / 150px);
   --slot-scale: calc(var(--card-scale) * .85);
@@ -414,14 +413,14 @@ body.mobile-landscape{
   --gem-size: 22px;
   --card-gem: calc(20px * var(--card-scale));
 
-  --top-strip-h: 60px;                    /* chip 38 + sub-strip ~18 (slot row is in the grid below) */
-  --hand-band-h: calc(var(--hand-card-h) + 16px);  /* extra room for the fan's vertical lift */
+  --top-strip-h: 60px;
+  --hand-band-h: calc(var(--hand-card-h) + 12px);
 }
 
 /* Board grid: 44px slot rows (taller so the dashed outlines render
    visibly, no longer compressed) + 1fr flow. */
 body.mobile-landscape #board-grid.grid{
-  grid-template-rows: 44px minmax(0, 1fr) 44px !important;
+  grid-template-rows: 48px minmax(0, 1fr) 48px !important;
   row-gap: 2px !important;
   padding: var(--top-strip-h) 6px var(--hand-band-h) !important;
   height: 100vh;


### PR DESCRIPTION
User feedback: hand should be smaller, field should be bigger. The hand was dominant (148 band, 100-wide cards) when it should be inventory; the field is the focal point.

## Hand smaller
- `--hand-card-w` clamp `(80, 11vw, 100)` → **`(60, 8.4vw, 75)`**. Cards ~75 wide max, ~99 tall.
- Hand-band buffer 16 → 12. Total band **~111px (was 148)**. Frees 37px for the field.

## Field bigger
- Slot rows: 44 → **48px**. `--card-h 40 → 44`, `--card-w clamp (40, 7.0vw, 50) → (44, 7.6vw, 56)`. Slot tiles ~12% bigger, placed cards more readable.
- Flow cards: `--flow-card-w clamp (64, 10vw, 82) → (70, 11vw, 90)`. `--flow-card-h` cap **122 → 144**. ~15% bigger and the 1fr zone is bigger thanks to the smaller hand band.

## Layout math (430px viewport)
`60 (HUD) + 48 (AI slots) + 2 + 1fr + 2 + 48 (player slots) + 111 (hand band) = 271 fixed → flow gets 159px for 144-tall flow cards (15px breathing).`

Field/hand proportion shifts from **130/148 (47% hand)** to **159/111 (41% hand)** — field-dominant.

Cache-bust `?v=mlv11-20260508`.

Single squashable commit `7912a54`.

---
_Generated by [Claude Code](https://claude.ai/code/session_01C1TYVtozydzcqvzpY15HMA)_