### PR TITLE
Mobile-landscape v13: turn-aware slots, smaller hand, cast impact

### DIFF
--- a/index.html
+++ b/index.html
@@ -5,7 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <title>The Grey — board</title>
   <link href="https://fonts.googleapis.com/css2?family=Cormorant+Garamond:wght@400;600&family=Crimson+Text:wght@600&display=swap" rel="stylesheet">
-  <link rel="stylesheet" href="./styles.css?v=mlv12-20260508" />
+  <link rel="stylesheet" href="./styles.css?v=mlv13-20260509" />
 </head>
 <body id="board" class="theme-dark parchment">
 
@@ -111,7 +111,7 @@
     </div>
   </div>
 
-  <script type="module" src="./index.js?v=mlv12-20260508"></script>
+  <script type="module" src="./index.js?v=mlv13-20260509"></script>
 </body>
 
 </html>

--- a/index.js
+++ b/index.js
@@ -1450,6 +1450,24 @@ Grey?.on?.('spotlight:cine', async ({ node, to, pose, slotIndex, cardId }) => {
 
     await playCinematic(data, startRect, destRect, { centerScale: 1.16, holdMs: 300, outMs: 260 });
 
+    // v13: card-play impact at destination — pulse + scale + colored
+    // glow keyed to card type so spells / instants / glyphs feel
+    // distinct on landing (MTGA-ish).
+    if (pose === 'play-spell' && Number.isFinite(slotIndex)){
+      const aiMini = document.getElementById('ai-mini');
+      const fromIsAI = !!(node.closest?.('.row.ai') || (aiMini && aiMini.contains(node)));
+      const rowSel = fromIsAI ? '.row.ai' : '.row.player';
+      const dest = document.querySelector(`${rowSel} .slot.spell[data-slot-index="${slotIndex}"]`);
+      if (dest){
+        dest.dataset.impactType = (data?.type || 'SPELL').toLowerCase();
+        dest.classList.remove('cast-impact');
+        // force reflow so the animation restarts even on rapid re-plays
+        void dest.offsetWidth;
+        dest.classList.add('cast-impact');
+        setTimeout(() => dest.classList.remove('cast-impact'), 700);
+      }
+    }
+
     // if the node still exists (wasn't removed by render), unhide it
     if (document.body.contains(node)) node.classList.remove('grey-hide-during-flight');
   } catch {}
@@ -5095,6 +5113,9 @@ let pipUIWired = false;
 
 async function render(){
   const s = ensureSafetyShape(serializePublic(state) || {});
+
+  // Mirror active side onto body so CSS can show/hide slot rows etc.
+  document.body.dataset.activeSide = (s.activePlayer === 'ai') ? 'ai' : 'player';
 
   // Wire pip click handlers once, after #player-slots exists
   if (!pipUIWired) {

--- a/styles.css
+++ b/styles.css
@@ -396,7 +396,7 @@ body.mobile-landscape{
   /* Hand cards: smaller — the hand is inventory, not the focal point.
      Was clamp(80,11vw,100); shrunk so the hand band is ~110 instead
      of ~148, freeing 38 vertical pixels for the field. */
-  --hand-card-w: clamp(60px, 8.4vw, 75px);
+  --hand-card-w: clamp(50px, 7.0vw, 64px);          /* v13: hand smaller still — inventory, not focal */
   --hand-card-h: calc(var(--hand-card-w) * 1.32);
   --hand-card-scale: calc(var(--hand-card-w) / 150px);
 
@@ -419,9 +419,39 @@ body.mobile-landscape{
 
 /* Board grid: 44px slot rows (taller so the dashed outlines render
    visibly, no longer compressed) + 1fr flow. */
+/* ===== v13: turn-aware slot rows =====
+   Only the active player's slot row is shown on mobile. The
+   inactive row collapses (grid track becomes 0) so the reclaimed
+   space goes to the flow row. The slot tiles also slide out via
+   transform so the transition reads as a coordinated "this player
+   isn't playing right now". */
+body.mobile-landscape[data-active-side="player"] #board-grid.grid{
+  grid-template-rows: 0 minmax(0, 1fr) 56px !important;
+}
+body.mobile-landscape[data-active-side="ai"] #board-grid.grid{
+  grid-template-rows: 56px minmax(0, 1fr) 0 !important;
+}
+body.mobile-landscape #ai-slots.slot-row,
+body.mobile-landscape #player-slots.slot-row{
+  transition: transform .26s ease, opacity .22s ease;
+}
+body.mobile-landscape[data-active-side="player"] #ai-slots.slot-row{
+  transform: translateY(-120%);
+  opacity: 0;
+  pointer-events: none;
+}
+body.mobile-landscape[data-active-side="ai"] #player-slots.slot-row{
+  transform: translateY(120%);
+  opacity: 0;
+  pointer-events: none;
+}
+
+/* Default grid (used when data-active-side hasn't been set yet, e.g.
+   first paint). Both rows visible at full height; v13 turn rules
+   above will override. */
 body.mobile-landscape #board-grid.grid{
-  grid-template-rows: 48px minmax(0, 1fr) 48px !important;
-  row-gap: 6px !important;                          /* more breathing between zones */
+  grid-template-rows: 56px minmax(0, 1fr) 56px !important;
+  row-gap: 6px !important;
   padding: var(--top-strip-h) 6px var(--hand-band-h) !important;
   height: 100vh;
   height: 100dvh;
@@ -711,6 +741,29 @@ body.mobile-landscape #ai-name{
    diamond indicators with roman numerals. Tap the chip on the desktop
    build to see full text; on mobile the lit diamond conveys the
    important state. */
+/* ===== v13: card-play impact ===== */
+@keyframes castImpactPulse {
+  0%   { box-shadow: 0 0 0 0 var(--impact-glow, rgba(198,165,106,.85)),
+                     inset 0 0 0 0 rgba(255,255,255,.5);
+         transform: scale(1.00); }
+  30%  { box-shadow: 0 0 0 22px rgba(0,0,0,0),
+                     inset 0 0 0 4px rgba(255,255,255,.35);
+         transform: scale(1.10); }
+  100% { box-shadow: 0 0 0 0 rgba(0,0,0,0),
+                     inset 0 0 0 0 rgba(255,255,255,0);
+         transform: scale(1.00); }
+}
+.slot.cast-impact {
+  animation: castImpactPulse 700ms cubic-bezier(.18,.9,.32,1.18);
+  z-index: 12;
+  --impact-glow: rgba(198,165,106,.85);
+}
+/* Type-keyed impact colors */
+.slot.cast-impact[data-impact-type="spell"]{   --impact-glow: rgba(126,182,255,.85); }
+.slot.cast-impact[data-impact-type="instant"]{ --impact-glow: rgba(255,160,120,.85); }
+.slot.cast-impact[data-impact-type="glyph"]{   --impact-glow: rgba(196,150,255,.85); }
+.slot.cast-impact[data-impact-type="reaction"]{--impact-glow: rgba(170,255,180,.85); }
+
 /* ===== v12 declutter: hide secondary state on mobile-landscape =====
    The sub-strip (trance pips + win-tracks) and the AI mini hand are
    still rendered in the DOM and visible on desktop, but on phone


### PR DESCRIPTION
Three user-requested improvements.

## 1) Turn-aware slot rows

- `render()` mirrors `state.activePlayer` onto `body.dataset.activeSide` (`'player'` or `'ai'`).
- Mobile-landscape: only the **active player's** slot row is shown.
  - Player's turn: AI slot row collapses (`grid-template-rows: 0 1fr 56`), AI tiles slide up + fade.
  - AI's turn: player slot row collapses, player tiles slide down.
- Reclaimed space goes to the **flow row** (1fr expands). The transform+opacity transition reads as a coordinated "this player isn't playing right now."

## 2) Hand cards smaller

- `--hand-card-w` clamp `(60, 8.4vw, 75)` → **`(50, 7.0vw, 64)`**.
- Cards top out at ~64 wide × ~85 tall; band ~95 (was ~111).
- Hand reads as inventory now, not the focal point.

## 3) Card-play impact (MTGA-ish)

- Spotlight cinematic handler (`spotlight:cine`) adds `.cast-impact` + `data-impact-type` to the destination slot after the flight cinematic lands.
- CSS keyframe `castImpactPulse` (700ms): scale `1.00 → 1.10 → 1.00`, expanding box-shadow halo, inset white flash.
- Type-keyed `--impact-glow` colors:
  - `spell` — blue `rgba(126,182,255,.85)`
  - `instant` — ember `rgba(255,160,120,.85)`
  - `glyph` — violet `rgba(196,150,255,.85)`
  - `reaction` — sage `rgba(170,255,180,.85)`
  - default — gold
- Reflow trick (`void offsetWidth` + remove/re-add class) so rapid re-plays of the same slot retrigger the animation.

Cache-bust `?v=mlv13-20260509`.

Single squashable commit `89b295c`.

---
_Generated by [Claude Code](https://claude.ai/code/session_01C1TYVtozydzcqvzpY15HMA)_