### PR TITLE
Mobile-portrait v14b: fix drag, restore tap-menu and peek

### DIFF
--- a/index.html
+++ b/index.html
@@ -5,7 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <title>The Grey — board</title>
   <link href="https://fonts.googleapis.com/css2?family=Cormorant+Garamond:wght@400;600&family=Crimson+Text:wght@600&display=swap" rel="stylesheet">
-  <link rel="stylesheet" href="./styles.css?v=mlv14a-20260509" />
+  <link rel="stylesheet" href="./styles.css?v=mlv14b-20260509" />
 </head>
 <body id="board" class="theme-dark parchment">
 
@@ -111,7 +111,7 @@
     </div>
   </div>
 
-  <script type="module" src="./index.js?v=mlv14a-20260509"></script>
+  <script type="module" src="./index.js?v=mlv14b-20260509"></script>
 </body>
 
 </html>

--- a/index.js
+++ b/index.js
@@ -2551,9 +2551,11 @@ await render();
   document.body.appendChild(pop);
   // Ensure reaction popovers appear above the dimming overlay and other UI
   pop.style.zIndex = 3600;
-  // On mobile-landscape the action-pop is styled as a fixed bottom sheet
-  // (see styles.css). Skip the per-card positioning so CSS controls layout.
-  if (!isMobileLandscape()){
+  // On mobile (both orientations) the action-pop is styled as a fixed
+  // bottom sheet (see styles.css). Skip the per-card positioning so
+  // CSS controls layout.
+  const isMobilePortrait = document.body?.classList?.contains('mobile-portrait');
+  if (!isMobileLandscape() && !isMobilePortrait){
     const r = cardEl.getBoundingClientRect();
     pop.style.left = `${r.left + r.width/2}px`;
     pop.style.top  = `${r.top  - 12}px`;

--- a/styles.css
+++ b/styles.css
@@ -975,7 +975,8 @@ body.mobile-landscape #btn-endturn-hud{
 }
 
 /* ===== Bottom action sheet (replaces tiny popover) ===== */
-body.mobile-landscape .action-pop{
+body.mobile-landscape .action-pop,
+body.mobile-portrait  .action-pop{
   position: fixed !important;
   left: 50% !important;
   bottom: calc(var(--hand-band-h) + 8px) !important;
@@ -988,17 +989,20 @@ body.mobile-landscape .action-pop{
   z-index: 9999;
   box-shadow: 0 12px 30px rgba(0,0,0,.6);
 }
-body.mobile-landscape .action-pop .rune-btn{
+body.mobile-landscape .action-pop .rune-btn,
+body.mobile-portrait  .action-pop .rune-btn{
   padding: 12px 18px; font-size: 1rem; border-radius: 10px;
   min-width: 78px; min-height: 44px;
 }
 
 /* Peek/Zoom: cap so it doesn't overflow short viewports */
 body.mobile-landscape #peek-card.card.peek,
-body.mobile-landscape #zoom-card.card.zoom{
-  width: min(calc(var(--hand-card-w)*1.7), 70vw);
+body.mobile-landscape #zoom-card.card.zoom,
+body.mobile-portrait  #peek-card.card.peek,
+body.mobile-portrait  #zoom-card.card.zoom{
+  width: min(calc(var(--hand-card-w)*1.9), 80vw);
   height: auto;
-  aspect-ratio: 1 / 1.34;
+  aspect-ratio: 1 / 1.4;
 }
 
 /* Very short displays */
@@ -2191,7 +2195,11 @@ body.mobile-portrait .flow-board .flow-price-num .n{
 body.mobile-portrait .hand-wrap{
   position: fixed; left: 0; right: 0; bottom: 0;
   height: var(--hand-band-h);
-  z-index: 40;
+  /* Higher than the FAB (z-index 51) and HUD piles (50) so that hand
+     cards, which extend visually over those buttons at the right
+     edge of the fan, actually receive touch events instead of having
+     them swallowed by the FAB. */
+  z-index: 60;
   background: linear-gradient(to top, rgba(15,12,9,.94) 60%, rgba(15,12,9,0));
   padding: 6px 8px calc(8px + env(safe-area-inset-bottom, 0px));
   box-sizing: border-box;
@@ -2204,7 +2212,11 @@ body.mobile-portrait .hand{
   width: 100%;
   height: var(--hand-band-h);
   perspective: 1200px;
-  pointer-events: auto;
+  /* Container itself is touch-transparent so taps over the empty
+     areas of the band (e.g. over the FAB at the right edge) reach
+     the buttons underneath. Only the cards themselves are
+     interactive. */
+  pointer-events: none;
   display: block;
   overflow: visible;
 }
@@ -2223,6 +2235,8 @@ body.mobile-portrait .hand .card{
   border-radius: 12px;
   box-shadow: 0 8px 18px rgba(0,0,0,.5);
   transition: transform .18s ease, box-shadow .14s ease-out;
+  /* Cards opt back in to receiving touches. */
+  pointer-events: auto;
   overflow: hidden;
 }
 body.mobile-portrait .hand .card.is-focus{


### PR DESCRIPTION
## Drag root cause: stacking-context inversion

`.hand-wrap` had `z-index: 40` and creates a stacking context, so child cards' `z-index: 400+` are scoped to that level (40). The End-turn FAB at `z-index: 51` was on top, intercepting touches over the rightmost cards even though they appeared to overlap the FAB.

**Fix**:
- `.hand-wrap` `z-index: 40 → 60` (above FAB and HUD piles).
- `.hand` container becomes `pointer-events: none`; individual `.card` elements opt back in via `pointer-events: auto`. Taps over the FAB/HUD area pass through `.hand` to the buttons underneath; direct taps on a card still hit the card.

## Tap menu (action-pop) was rendering off-screen

`showCardOptions()` skipped per-card positioning only on `isMobileLandscape()` — on portrait it positioned the pop relative to the card, often behind the hand band or off-screen.

**Fix**:
- Detect mobile-portrait too and skip per-card positioning.
- CSS: extend the mobile-landscape `.action-pop` bottom-sheet rule to portrait. The pop appears as a horizontal sheet just above the hand band, 44px-min tap targets, `z-index: 9999`.

## Peek / zoom was desktop-sized on portrait

Extended the landscape peek/zoom sizing rule to portrait, with aspect 1.34 → **1.4** to match the v14a TCG ratio. Cards in peek/zoom render at `min(1.9 × hand-card-w, 80vw)`.

Cache-bust `?v=mlv14b-20260509`.

Single squashable commit `3968d7d`.

---
_Generated by [Claude Code](https://claude.ai/code/session_01C1TYVtozydzcqvzpY15HMA)_