### PR TITLE
Mobile v14c: right-size the played-card peek

### DIFF
--- a/index.html
+++ b/index.html
@@ -5,7 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <title>The Grey — board</title>
   <link href="https://fonts.googleapis.com/css2?family=Cormorant+Garamond:wght@400;600&family=Crimson+Text:wght@600&display=swap" rel="stylesheet">
-  <link rel="stylesheet" href="./styles.css?v=mlv14b-20260509" />
+  <link rel="stylesheet" href="./styles.css?v=mlv14c-20260509" />
 </head>
 <body id="board" class="theme-dark parchment">
 
@@ -111,7 +111,7 @@
     </div>
   </div>
 
-  <script type="module" src="./index.js?v=mlv14b-20260509"></script>
+  <script type="module" src="./index.js?v=mlv14c-20260509"></script>
 </body>
 
 </html>

--- a/styles.css
+++ b/styles.css
@@ -996,13 +996,33 @@ body.mobile-portrait  .action-pop .rune-btn{
 }
 
 /* Peek/Zoom: cap so it doesn't overflow short viewports */
+/* Peek/Zoom: capped so it doesn't dominate the screen on phone.
+   Hearthstone/StS-style modest peek ~ 40-50% of screen height. */
 body.mobile-landscape #peek-card.card.peek,
-body.mobile-landscape #zoom-card.card.zoom,
-body.mobile-portrait  #peek-card.card.peek,
-body.mobile-portrait  #zoom-card.card.zoom{
-  width: min(calc(var(--hand-card-w)*1.9), 80vw);
+body.mobile-landscape #zoom-card.card.zoom{
+  width: min(calc(var(--hand-card-w)*1.9), 50vw);
   height: auto;
   aspect-ratio: 1 / 1.4;
+  max-height: 70vh;
+}
+body.mobile-portrait #peek-card.card.peek,
+body.mobile-portrait #zoom-card.card.zoom{
+  /* On portrait the constraint is HEIGHT (tall but narrow viewport).
+     Cap at 45vh which lands a 1.4-aspect card at ~32vw wide. */
+  width: auto;
+  height: 45vh;
+  aspect-ratio: 1 / 1.4;
+  max-width: 70vw;
+}
+/* Smooth scale-in for both modes */
+body.mobile-landscape #peek-card.card.peek,
+body.mobile-portrait #peek-card.card.peek{
+  transform: translate(-50%, -50%) scale(.92);
+  transition: opacity .16s ease, transform .16s ease;
+}
+body.mobile-landscape #peek-card.card.peek.show,
+body.mobile-portrait #peek-card.card.peek.show{
+  transform: translate(-50%, -50%) scale(1);
 }
 
 /* Very short displays */


### PR DESCRIPTION
From the screenshot: a played card was popping in at ~80% of screen height, dominating everything. That overlay is the long-press peek (`#peek-card`). v14b sized it as `min(hand-card-w * 1.9, 80vw) aspect 1/1.4`, which on a 430-wide portrait phone resolved to 80vw wide × ~480 tall.

## Right-size to Hearthstone/StS proportions

**Portrait** — `height: 45vh; width: auto; aspect-ratio: 1/1.4; max-width: 70vw`. Lands at ~32vw × 45vh — visible without drowning the board.

**Landscape** — `width: min(hand-card-w * 1.9, 50vw); aspect 1/1.4; max-height: 70vh`. Tightened from `80vw / no max-height`.

## Smooth scale-in

Peek transitions opacity AND `transform` from `scale(.92)` → `scale(1.00)` over 160ms. Reads as a card popping forward deliberately instead of an instant overlay.

Cache-bust `?v=mlv14c-20260509`.

Single squashable commit `c96e51e`.

---
_Generated by [Claude Code](https://claude.ai/code/session_01C1TYVtozydzcqvzpY15HMA)_