### PR TITLE
Mobile v14d: cap the spotlight cinematic on phone

### DIFF
--- a/index.html
+++ b/index.html
@@ -5,7 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <title>The Grey — board</title>
   <link href="https://fonts.googleapis.com/css2?family=Cormorant+Garamond:wght@400;600&family=Crimson+Text:wght@600&display=swap" rel="stylesheet">
-  <link rel="stylesheet" href="./styles.css?v=mlv14c-20260509" />
+  <link rel="stylesheet" href="./styles.css?v=mlv14d-20260509" />
 </head>
 <body id="board" class="theme-dark parchment">
 
@@ -111,7 +111,7 @@
     </div>
   </div>
 
-  <script type="module" src="./index.js?v=mlv14c-20260509"></script>
+  <script type="module" src="./index.js?v=mlv14d-20260509"></script>
 </body>
 
 </html>

--- a/styles.css
+++ b/styles.css
@@ -1135,6 +1135,17 @@ body.mobile-portrait #peek-card.card.peek.show{
   position: absolute !important;
 }
 
+/* On phones cap the cinematic spotlight at a reasonable fraction of
+   the viewport (~38% wide) so the played-card hold doesn't fill
+   half the screen. JS still applies centerScale (~1.16), so peak
+   render is ~44% wide. */
+body.mobile-landscape .cinematic-layer .card,
+body.mobile-portrait  .cinematic-layer .card{
+  width: clamp(120px, 38vw, 170px) !important;
+  height: auto !important;
+  aspect-ratio: 1 / 1.4 !important;
+}
+
 
 /* Cinematic layer */
 .cinematic-layer {


### PR DESCRIPTION
From the screenshot: a played card ("Glyph of Returning Echo") was filling half the screen during the play animation. That's not the long-press peek — it's the **cinematic spotlight ghost** from `playCinematic()`, which the desktop CSS forces to a fixed `240×336` with `!important`. On a 430-wide portrait phone that's 56% of the viewport at rest, and after `centerScale: 1.16` it peaks at ~65%.

## Cap on mobile

```css
body.mobile-landscape .cinematic-layer .card,
body.mobile-portrait  .cinematic-layer .card{
  width: clamp(120px, 38vw, 170px) !important;
  height: auto !important;
  aspect-ratio: 1 / 1.4 !important;
}
```

On a 430-wide phone: ~163 × 228 at rest. After centerScale 1.16: ~190 × 265 at peak (~44% of viewport width). Visible enough to be a "played card" moment without dominating the board, and aspect 1.4 matches the v14a TCG ratio applied to the rest of the cards.

Cache-bust `?v=mlv14d-20260509`.

Single squashable commit `36da001`.

---
_Generated by [Claude Code](https://claude.ai/code/session_01C1TYVtozydzcqvzpY15HMA)_