### PR TITLE
Mobile v15: legible spotlight cards + slower cinematic pacing

### DIFF
--- a/index.html
+++ b/index.html
@@ -5,7 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <title>The Grey — board</title>
   <link href="https://fonts.googleapis.com/css2?family=Cormorant+Garamond:wght@400;600&family=Crimson+Text:wght@600&display=swap" rel="stylesheet">
-  <link rel="stylesheet" href="./styles.css?v=mlv14d-20260509" />
+  <link rel="stylesheet" href="./styles.css?v=mlv15-20260509" />
 </head>
 <body id="board" class="theme-dark parchment">
 
@@ -111,7 +111,7 @@
     </div>
   </div>
 
-  <script type="module" src="./index.js?v=mlv14d-20260509"></script>
+  <script type="module" src="./index.js?v=mlv15-20260509"></script>
 </body>
 
 </html>

--- a/index.js
+++ b/index.js
@@ -4186,6 +4186,12 @@ async function playCinematic(cardData, startRect, destRect, opts = {}) {
   const layer = ensureCinematicLayer();
   const ghost = makeFloatingCard(cardData);
 
+  // v15: on phones, slow the whole flight so the player can register
+  // what just happened. Desktop stays at 1.0x because the card is
+  // bigger and chains are easier to track.
+  const isMob = isMobileLandscape() || document.body?.classList?.contains('mobile-portrait');
+  const slow = isMob ? 1.6 : 1.0;
+
   const stackKey   = opts.stackKey || null;
   const stackIndex = Number.isFinite(opts.stackIndex) ? (opts.stackIndex|0) : 0;
   const stackDx    = Number.isFinite(opts.stackDx) ? opts.stackDx : 26;
@@ -4227,9 +4233,9 @@ async function playCinematic(cardData, startRect, destRect, opts = {}) {
     `translate(${(anchorPose.x - (startRect?.x ?? anchorPose.x)) + offsetX}px, ${(anchorPose.y - (startRect?.y ?? anchorPose.y)) + offsetY}px) scale(${baseScale})`;
   ghost.style.opacity = '1';
 
-  await sleep(opts.poseInMs ?? 240);
+  await sleep((opts.poseInMs ?? 240) * slow);
   ghost.classList.add('pose');
-  await sleep(opts.holdMs ?? 360);
+  await sleep((opts.holdMs ?? 360) * slow);
 
   const endX = (destRect?.x ?? anchorPose.x);
   const endY = (destRect?.y ?? anchorPose.y);
@@ -4241,7 +4247,7 @@ async function playCinematic(cardData, startRect, destRect, opts = {}) {
     `translate(${endX - (startRect?.x ?? anchorPose.x)}px, ${endY - (startRect?.y ?? anchorPose.y)}px) scale(${scaleOut})`;
   ghost.style.opacity = '0.001';
 
-  await sleep(opts.outMs ?? 260);
+  await sleep((opts.outMs ?? 260) * slow);
   ghost.remove();
 
   if (opts.stackKey) setTimeout(() => SPOTLIGHT_STACKS.delete(opts.stackKey), 1200);

--- a/styles.css
+++ b/styles.css
@@ -1138,12 +1138,44 @@ body.mobile-portrait #peek-card.card.peek.show{
 /* On phones cap the cinematic spotlight at a reasonable fraction of
    the viewport (~38% wide) so the played-card hold doesn't fill
    half the screen. JS still applies centerScale (~1.16), so peak
-   render is ~44% wide. */
+   render is ~44% wide.
+
+   v15: also override --card-scale so the card's inner text/icons
+   scale to the cinematic card's actual width instead of inheriting
+   the page-level --card-scale (which is set for slot tiles ~0.5 on
+   phone, making spotlight text half-size). At ~165px wide that's
+   165/150 = 1.1. */
 body.mobile-landscape .cinematic-layer .card,
 body.mobile-portrait  .cinematic-layer .card{
   width: clamp(120px, 38vw, 170px) !important;
   height: auto !important;
   aspect-ratio: 1 / 1.4 !important;
+  --card-scale: 1.1 !important;
+  --card-gem: 24px !important;
+  font-size: calc(1rem * 1.1) !important;
+  /* Stronger spotlight glow so the card reads as the focal moment */
+  box-shadow:
+    0 18px 36px rgba(0,0,0,.7),
+    0 0 28px rgba(198,165,106,.45),
+    0 0 0 1px rgba(198,165,106,.35) inset !important;
+}
+/* Make the rules text itself a bit punchier on mobile spotlight,
+   since these cards hold for ~half a second and the player needs
+   to actually read them. */
+body.mobile-landscape .cinematic-layer .card .title,
+body.mobile-portrait  .cinematic-layer .card .title{
+  font-size: 1.05em !important;
+  font-weight: 700;
+}
+body.mobile-landscape .cinematic-layer .card .textbox,
+body.mobile-portrait  .cinematic-layer .card .textbox{
+  line-height: 1.25 !important;
+  font-size: 0.92em !important;
+}
+body.mobile-landscape .cinematic-layer .card .type,
+body.mobile-portrait  .cinematic-layer .card .type{
+  font-size: 0.85em !important;
+  letter-spacing: .04em;
 }
 
 


### PR DESCRIPTION
## Two fixes addressing "fast and unclear, hard-to-read text"

### 1. Spotlight card text legibility

Cinematic cards inherited the page-level `--card-scale`, which on `mobile-portrait` is set for slot tiles (~76/150 = **0.5**). That made spotlight text render at half-size — basically unreadable in the ~600ms hold.

Override on mobile:
```css
body.mobile-* .cinematic-layer .card{
  --card-scale: 1.1;
  --card-gem: 24px;
  font-size: calc(1rem * 1.1);
  /* punchier glow + gold ring inset */
  box-shadow:
    0 18px 36px rgba(0,0,0,.7),
    0 0 28px rgba(198,165,106,.45),
    0 0 0 1px rgba(198,165,106,.35) inset;
}
```

Plus explicit text sizing:
- `.title` `1.05em / 700`
- `.textbox` `0.92em / line-height 1.25`
- `.type` `0.85em / +.04em letter-spacing`

### 2. Cinematic pacing

`playCinematic()` now applies a **1.6× slowdown** to `poseInMs / holdMs / outMs` on mobile (both orientations). Desktop unchanged.

| Phase | Before | After (mobile) |
|---|---|---|
| poseIn | 240ms | 384ms |
| hold | 360ms | 576ms |
| out | 260ms | 416ms |
| total | 860ms | **1376ms** |

Chains of resolves stop blurring together; player has time to read each card before the next one comes through.

Cache-bust `?v=mlv15-20260509`.

Single squashable commit `367a92e`.

---
_Generated by [Claude Code](https://claude.ai/code/session_01C1TYVtozydzcqvzpY15HMA)_