### PR TITLE
Mobile v16: spotlight cap + game-feel pass (turn badge, Æ floater, AI toast, stagger)

### DIFF
--- a/index.html
+++ b/index.html
@@ -5,7 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <title>The Grey — board</title>
   <link href="https://fonts.googleapis.com/css2?family=Cormorant+Garamond:wght@400;600&family=Crimson+Text:wght@600&display=swap" rel="stylesheet">
-  <link rel="stylesheet" href="./styles.css?v=mlv15-20260509" />
+  <link rel="stylesheet" href="./styles.css?v=mlv16-20260509" />
 </head>
 <body id="board" class="theme-dark parchment">
 
@@ -20,6 +20,9 @@
       <span id="aether-readout" class="aether">Æ 0  ◇ 0</span>
     </div>
   </header>
+
+  <!-- v16: persistent turn badge for mobile (hidden on desktop via CSS) -->
+  <div id="turn-badge" aria-live="polite"></div>
 
   <main id="board-grid" class="grid">
     <!-- AI (top) -->
@@ -111,7 +114,7 @@
     </div>
   </div>
 
-  <script type="module" src="./index.js?v=mlv15-20260509"></script>
+  <script type="module" src="./index.js?v=mlv16-20260509"></script>
 </body>
 
 </html>

--- a/index.js
+++ b/index.js
@@ -608,6 +608,26 @@ function animateDamage(side, amount = 1) {
 }
 
 
+// v16: +X Æ floater — mirrors animateDamage's lifecycle but rises
+// from the chip's aether display in blue. Triggered on
+// Events.AETHER_GAIN (channel rewards, Morr L1, Enoch L1, Veyra I,
+// flow buy resolution).
+function animateAetherGain(side, amount /*, source */) {
+  const n = amount | 0;
+  if (!n) return;
+  const aetherEl = document.getElementById(side === 'player' ? 'player-aether' : 'ai-aether');
+  const host = aetherEl?.closest('.portrait') || document.body;
+  if (!host) return;
+  // Ensure we have a positioning context relative to the chip
+  const cs = window.getComputedStyle(host);
+  if (cs.position === 'static') host.style.position = 'relative';
+
+  const floater = document.createElement('div');
+  floater.className = 'aether-float blue';
+  floater.textContent = `+${n} Æ`;
+  host.appendChild(floater);
+  floater.addEventListener('animationend', () => floater.remove(), { once: true });
+}
 
 
 
@@ -1904,13 +1924,68 @@ Grey.on?.(Events.TURN_START, async ({ side }) => {
 });
 
 
+// v16: AI action toast — small fading pill near the AI chip showing
+// what the opponent just did. Triggered from the event handlers
+// below when side === 'ai'.
+let aiToastEl = null, aiToastTimer = null;
+function aiActionToast(text) {
+  if (!aiToastEl) {
+    aiToastEl = document.createElement('div');
+    aiToastEl.id = 'ai-toast';
+    document.body.appendChild(aiToastEl);
+  }
+  aiToastEl.textContent = text;
+  aiToastEl.classList.add('show');
+  clearTimeout(aiToastTimer);
+  aiToastTimer = setTimeout(() => {
+    aiToastEl?.classList.remove('show');
+  }, 1500);
+}
+
+// Lookup card name across hand/flow so toasts and similar UI can
+// label opponent actions ("Opponent played Hexing Wisp") without
+// just printing the cardId.
+function cardNameFromId(cardId){
+  if (!cardId) return 'a card';
+  try {
+    const pub = serializePublic(state) || {};
+    const all = [
+      ...((pub.players?.player?.hand)||[]),
+      ...((pub.players?.ai?.hand)||[]),
+      ...((pub.flow)||[]),
+    ].filter(Boolean);
+    const found = all.find(c => c?.id === cardId);
+    return found?.name || 'a card';
+  } catch { return 'a card'; }
+}
+
 Grey.on?.(Events.TURN_END,   ({side}) => logLine(`Turn end   → ${side}`));
-Grey.on?.(Events.CARD_PLAYED, ({side, cardId, cost}) => logLine(`${side} PLAY spell ${cardId} (cost ${cost ?? 0})`));
-Grey.on?.(Events.CARD_SET,    ({side, cardId}) => logLine(`${side} SET glyph ${cardId}`));
-Grey.on?.(Events.CARD_CAST,   ({side, cardId, cost}) => logLine(`${side} CAST instant ${cardId} (cost ${cost ?? 0})`));
-Grey.on?.(Events.CHANNEL,     ({side, cardId, gained}) => logLine(`${side} CHANNEL ${cardId} → +${gained} Æ (temp)`));
-Grey.on?.(Events.BUY,         ({side, idx, price}) => logLine(`${side} BOUGHT flow[${idx}] for ${price} Æ`));
-Grey.on?.(Events.AETHER_GAIN, ({side, amount, source}) => logLine(`${side} +${amount} Æ (${source||"effect"})`));
+Grey.on?.(Events.CARD_PLAYED, ({side, cardId, cost}) => {
+  logLine(`${side} PLAY spell ${cardId} (cost ${cost ?? 0})`);
+  if (side === 'ai') aiActionToast(`Opponent played ${cardNameFromId(cardId)}`);
+});
+Grey.on?.(Events.CARD_SET,    ({side, cardId}) => {
+  logLine(`${side} SET glyph ${cardId}`);
+  if (side === 'ai') aiActionToast(`Opponent set ${cardNameFromId(cardId)}`);
+});
+Grey.on?.(Events.CARD_CAST,   ({side, cardId, cost}) => {
+  logLine(`${side} CAST instant ${cardId} (cost ${cost ?? 0})`);
+  if (side === 'ai') aiActionToast(`Opponent cast ${cardNameFromId(cardId)}`);
+});
+Grey.on?.(Events.CHANNEL,     ({side, cardId, gained}) => {
+  logLine(`${side} CHANNEL ${cardId} → +${gained} Æ (temp)`);
+  // Channel temp gains are also surfaced as aether floaters so the
+  // player feels every +Æ resource event consistently.
+  animateAetherGain(side, gained);
+});
+Grey.on?.(Events.BUY,         ({side, idx, price}) => {
+  logLine(`${side} BOUGHT flow[${idx}] for ${price} Æ`);
+  if (side === 'ai') aiActionToast(`Opponent bought a card`);
+});
+Grey.on?.(Events.AETHER_GAIN, ({side, amount, source}) => {
+  logLine(`${side} +${amount} Æ (${source||"effect"})`);
+  animateAetherGain(side, amount, source);
+});
 
 
 // === AI → cinematic bridge ===
@@ -4585,6 +4660,14 @@ async function spotlightFromEvents(state){
 
     } catch (_err) {
       // swallow to avoid breaking the loop on animation errors
+    }
+
+    // v16: small inter-event beat on mobile so chains of resolves
+    // feel choreographed instead of mashed together. Desktop stays
+    // tight at 0ms.
+    if (i < evts.length - 1) {
+      const isMob = isMobileLandscape() || document.body?.classList?.contains('mobile-portrait');
+      if (isMob) await sleep(180);
     }
   }
 

--- a/styles.css
+++ b/styles.css
@@ -1145,37 +1145,28 @@ body.mobile-portrait #peek-card.card.peek.show{
    the page-level --card-scale (which is set for slot tiles ~0.5 on
    phone, making spotlight text half-size). At ~165px wide that's
    165/150 = 1.1. */
+/* v16: strict cap on cinematic spotlight.
+   Previous v15 used height:auto + aspect-ratio + explicit font bumps
+   on .title/.textbox/.type — but `.card { display:flex; flex-direction:
+   column }` + `.textbox { flex:1 }` means aspect-ratio acts as a
+   minimum; long rules text + bumped fonts pushed intrinsic content
+   height past the 1.4 ratio and the card grew tall to fit (50%+ of
+   screen). Now the height is hard-clamped and overflow clips. The
+   v15 explicit per-element font bumps are dropped so content scales
+   uniformly via --card-scale. */
 body.mobile-landscape .cinematic-layer .card,
 body.mobile-portrait  .cinematic-layer .card{
-  width: clamp(120px, 38vw, 170px) !important;
-  height: auto !important;
-  aspect-ratio: 1 / 1.4 !important;
+  width:  clamp(120px, 38vw, 170px) !important;
+  height: clamp(168px, calc(38vw * 1.4), 238px) !important;
+  aspect-ratio: auto !important;
+  overflow: hidden !important;
   --card-scale: 1.1 !important;
   --card-gem: 24px !important;
   font-size: calc(1rem * 1.1) !important;
-  /* Stronger spotlight glow so the card reads as the focal moment */
   box-shadow:
     0 18px 36px rgba(0,0,0,.7),
     0 0 28px rgba(198,165,106,.45),
     0 0 0 1px rgba(198,165,106,.35) inset !important;
-}
-/* Make the rules text itself a bit punchier on mobile spotlight,
-   since these cards hold for ~half a second and the player needs
-   to actually read them. */
-body.mobile-landscape .cinematic-layer .card .title,
-body.mobile-portrait  .cinematic-layer .card .title{
-  font-size: 1.05em !important;
-  font-weight: 700;
-}
-body.mobile-landscape .cinematic-layer .card .textbox,
-body.mobile-portrait  .cinematic-layer .card .textbox{
-  line-height: 1.25 !important;
-  font-size: 0.92em !important;
-}
-body.mobile-landscape .cinematic-layer .card .type,
-body.mobile-portrait  .cinematic-layer .card .type{
-  font-size: 0.85em !important;
-  letter-spacing: .04em;
 }
 
 
@@ -2471,3 +2462,70 @@ body.mobile-portrait #weaver-backdrop img{
   bottom: 0 !important;
   filter: saturate(.7) brightness(.65);
 }
+
+
+/* ==========================================================
+   v16: GAME-FEEL improvements
+   - Persistent turn badge on mobile (#turn-badge)
+   - +X Æ gain floater (.aether-float)
+   - AI action toast (#ai-toast)
+   ========================================================== */
+
+/* Turn badge: hidden on desktop, small pill at top-center on phones.
+   Driven entirely by body[data-active-side] which render() already
+   sets. ::before content swap means no JS for this element. */
+#turn-badge { display: none; }
+body.mobile-portrait #turn-badge,
+body.mobile-landscape #turn-badge {
+  display: inline-block;
+  position: fixed; top: 4px; left: 50%; transform: translateX(-50%);
+  padding: 4px 10px; border-radius: 999px;
+  background: rgba(20,16,12,.78); border: 1px solid #4a3d2f;
+  font-size: .65rem; font-weight: 700; letter-spacing: .06em;
+  color: #c6a56a; text-transform: uppercase;
+  z-index: 35; pointer-events: none;
+  white-space: nowrap;
+}
+body[data-active-side="player"] #turn-badge::before { content: "Your Turn"; }
+body[data-active-side="ai"]     #turn-badge::before {
+  content: "Opponent's Turn";
+  color: #d97a7a;
+}
+
+/* Æ gain floater — mirrors the damage -N floater (animateDamage in
+   index.js:552), but blue and rises from the aether display. */
+.aether-float {
+  position: absolute; pointer-events: none; z-index: 9000;
+  font-weight: 800; font-size: 18px;
+  color: #7eb6ff;
+  text-shadow:
+    0 1px 2px rgba(0,0,0,.85),
+    0 0 8px rgba(126,182,255,.55);
+  left: 50%; top: 0;
+  transform: translate(-50%, 0);
+  animation: aetherFloatRise 900ms ease-out forwards;
+  white-space: nowrap;
+}
+@keyframes aetherFloatRise {
+  0%   { opacity: 0; transform: translate(-50%, 8px)  scale(.92); }
+  20%  { opacity: 1; transform: translate(-50%, -4px) scale(1.05); }
+  100% { opacity: 0; transform: translate(-50%, -42px) scale(1.00); }
+}
+
+/* AI action toast — brief 1.5s pill near the AI chip when the
+   opponent plays, sets, or buys a card. Small reddish border so
+   it reads as "their action" not yours. */
+#ai-toast {
+  position: fixed; top: 46px; right: 8px;
+  max-width: min(60vw, 260px);
+  padding: 6px 10px; border-radius: 8px;
+  background: rgba(20,16,12,.92);
+  border: 1px solid #6a3a3a;
+  color: #e7dcc3; font-size: .72rem; line-height: 1.2;
+  opacity: 0;
+  transform: translateY(-4px);
+  transition: opacity .18s ease, transform .18s ease;
+  z-index: 5000; pointer-events: none;
+  box-shadow: 0 6px 14px rgba(0,0,0,.5);
+}
+#ai-toast.show { opacity: 1; transform: translateY(0); }


### PR DESCRIPTION
User feedback: "Card spotlight is way too big now... it's not fun at the moment either."

Two related fixes in one PR — the spotlight bug and the moment-to-moment feedback gaps both come down to weak signaling.

## 1. Spotlight: strict cap

v15 used `height: auto + aspect-ratio: 1/1.4`, which acts as a *minimum* — `.card { display: flex; flex-direction: column }` + `.textbox { flex: 1 }` + the v15 explicit font bumps inflated content beyond the 1.4 ratio, so the card grew tall to fit (≈50% of screen on the user's screenshot).

```css
body.mobile-* .cinematic-layer .card{
  width:  clamp(120px, 38vw, 170px) !important;
  height: clamp(168px, calc(38vw * 1.4), 238px) !important;
  aspect-ratio: auto !important;
  overflow: hidden !important;
  --card-scale: 1.1 !important;
  /* ... */
}
```

Dropped the per-element `.title / .textbox / .type` font-size overrides; trust `--card-scale: 1.1` to scale uniformly. Long rules text clips at the bottom — acceptable for read-at-a-glance.

## 2. Game-feel pass

Survey identified four moments where the player loses track. Fixed all four.

### Persistent turn badge (mobile)
Top-center pill — gold **"YOUR TURN"** / red **"OPPONENT'S TURN"**. Pure CSS via `body[data-active-side]` (already set by `render()` for v13's turn-aware slot rows). No JS for this element.

### +X Æ gain floater
`animateAetherGain()` mirrors the existing `animateDamage()` lifecycle but blue, rises from the chip's aether display.

Wired to **`Events.AETHER_GAIN`** (Morr L1, Enoch L1, Veyra I, buy resolution) AND **`Events.CHANNEL`** so every aether tick pops a `+N`. Parity with damage's red `-N`.

### AI action toast
1.5s fading pill below the AI chip naming what the opponent just did:
- "Opponent played Hexing Wisp"
- "Opponent set Glyph of Returning Echo"
- "Opponent cast Aether Burst"
- "Opponent bought a card"

Wired to AI-side `Events.CARD_PLAYED / CARD_SET / CARD_CAST / BUY`. Reuses `serializePublic()` to resolve card names; falls back to "a card".

### Inter-event stagger (180ms on mobile)
`spotlightFromEvents()` loop sleeps **180ms between events** on mobile (only between, not trailing). Chains of 3-5 resolves stop blurring; each cinematic gets a beat to land before the next.

## Files
- `index.html` — `<div id="turn-badge">`, cache-bust
- `styles.css` — strict cinematic cap (~line 1148); v16 game-feel block at end (`#turn-badge`, `.aether-float`, `#ai-toast`)
- `index.js` — `animateAetherGain` (~line 610), `aiActionToast`/`cardNameFromId` (~line 1927), wired event handlers (~line 1933+), inter-event stagger in `spotlightFromEvents` (~line 4664)

Cache-bust `?v=mlv16-20260509`. Single squashable commit `8a0bf36`.

---
_Generated by [Claude Code](https://claude.ai/code/session_01C1TYVtozydzcqvzpY15HMA)_