### PR TITLE
v17: game-flow clarity pass (subtitles, slot pulse, wincon strip, trance + hex moments, first-run welcome)

### DIFF
--- a/index.html
+++ b/index.html
@@ -5,7 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <title>The Grey — board</title>
   <link href="https://fonts.googleapis.com/css2?family=Cormorant+Garamond:wght@400;600&family=Crimson+Text:wght@600&display=swap" rel="stylesheet">
-  <link rel="stylesheet" href="./styles.css?v=mlv16-20260509" />
+  <link rel="stylesheet" href="./styles.css?v=mlv17-20260509" />
 </head>
 <body id="board" class="theme-dark parchment">
 
@@ -23,6 +23,70 @@
 
   <!-- v16: persistent turn badge for mobile (hidden on desktop via CSS) -->
   <div id="turn-badge" aria-live="polite"></div>
+
+  <!-- v17: always-visible win-condition tracker (both sides) -->
+  <div id="wincon-strip" aria-label="Win condition progress">
+    <div class="wc-row wc-ai" data-side="ai">
+      <span class="wc-hp" title="Vitality (Ruin at 0)">
+        <span class="wc-icon" aria-hidden="true">♥</span>
+        <span class="wc-val">12</span>
+      </span>
+      <span class="wc-cf" title="Confluence: buy 5 from Aether Flow">
+        <span class="wc-icon" aria-hidden="true">◇</span>
+        <span class="wc-val">0/5</span>
+      </span>
+      <span class="wc-dm" title="Dominion: channel 10+ Aether">
+        <span class="wc-icon" aria-hidden="true">▲</span>
+        <span class="wc-val">0/10</span>
+      </span>
+    </div>
+    <div class="wc-row wc-player" data-side="player">
+      <span class="wc-hp" title="Vitality (Ruin at 0)">
+        <span class="wc-icon" aria-hidden="true">♥</span>
+        <span class="wc-val">12</span>
+      </span>
+      <span class="wc-cf" title="Confluence: buy 5 from Aether Flow">
+        <span class="wc-icon" aria-hidden="true">◇</span>
+        <span class="wc-val">0/5</span>
+      </span>
+      <span class="wc-dm" title="Dominion: channel 10+ Aether">
+        <span class="wc-icon" aria-hidden="true">▲</span>
+        <span class="wc-val">0/10</span>
+      </span>
+    </div>
+  </div>
+  <div id="wincon-explain" role="dialog" aria-hidden="true">
+    <button class="close" aria-label="Close">×</button>
+    <h4>Three paths to victory</h4>
+    <p><b>♥ Ruin</b> — drop opponent's Vitality to 0.</p>
+    <p><b>◇ Confluence</b> — buy 5 cards from the Aether Flow market.</p>
+    <p><b>▲ Dominion</b> — channel 10+ Aether (discard cards, certain effects).</p>
+  </div>
+
+  <!-- v17: first-run welcome overlay (one-time; localStorage flag) -->
+  <div id="welcome-overlay" data-shown="false" aria-hidden="true">
+    <div class="welcome-panel" role="dialog" aria-labelledby="welcome-title">
+      <h2 id="welcome-title">The Grey</h2>
+      <p class="welcome-tagline">A duel of weavers. Three paths to victory.</p>
+      <h3>How to win</h3>
+      <ul class="welcome-paths">
+        <li><b>Ruin</b> — drop your opponent to 0 hearts.</li>
+        <li><b>Confluence</b> — buy 5 cards from the Aether Flow.</li>
+        <li><b>Dominion</b> — channel 10 or more Aether.</li>
+      </ul>
+      <h3>Your turn</h3>
+      <p class="welcome-tip">
+        Tap a card in your hand to see what you can do — Play it to a Spell Slot,
+        Set it as a Glyph, Cast it, or Channel it for Aether. Pay Aether to advance
+        your Spells; once a spell hits its pip count, it resolves.
+      </p>
+      <p class="welcome-tip">
+        Long-press any card to read its full text. The bar at the top tracks your
+        progress on all three win conditions — tap it for a reminder.
+      </p>
+      <button id="welcome-dismiss" class="rune-btn">Begin</button>
+    </div>
+  </div>
 
   <main id="board-grid" class="grid">
     <!-- AI (top) -->
@@ -114,7 +178,7 @@
     </div>
   </div>
 
-  <script type="module" src="./index.js?v=mlv16-20260509"></script>
+  <script type="module" src="./index.js?v=mlv17-20260509"></script>
 </body>
 
 </html>

--- a/index.js
+++ b/index.js
@@ -2480,14 +2480,20 @@ function showCardOptions(cardEl, cardData){
   clearAllActionMenus();
   const pub = serializePublic(state) || {};
   const opts = [];
-  if (canPlaySpell(pub, cardData))  opts.push({k:"play",    label:"Play"});
-  if (canSetGlyph(pub, cardData))   opts.push({k:"set", label: glyphSlotOccupied(pub) ? "Replace" : "Set"});
+  if (canPlaySpell(pub, cardData))  opts.push({k:"play", label:"Play",
+    desc:"Send to a Spell Slot"});
+  if (canSetGlyph(pub, cardData))   opts.push({k:"set",
+    label: glyphSlotOccupied(pub) ? "Replace" : "Set",
+    desc: glyphSlotOccupied(pub) ? "Swap your Glyph (passive)" : "Place as Glyph (passive)"});
   // Only offer cast on true INSTANTs; Reaction cards are handled via "React" when a reaction window is active
-  if (canCastInstant(pub, cardData) && cardData.type !== 'REACTION') opts.push({k:"cast",    label:"Cast"});
+  if (canCastInstant(pub, cardData) && cardData.type !== 'REACTION') opts.push({k:"cast",
+    label:"Cast", desc:"Resolve immediately"});
   if (canChannel(cardData)){
     // Label as "Discard" if the card doesn't grant any Æ when channeled
-    const label = ((cardData?.aetherValue|0) > 0) ? "Channel" : "Discard";
-    opts.push({k:"channel", label});
+    const ae = (cardData?.aetherValue|0);
+    const label = ae > 0 ? "Channel" : "Discard";
+    const desc  = ae > 0 ? `Discard for +${ae} Æ this turn` : "Send to discard pile";
+    opts.push({k:"channel", label, desc});
   }
   // If this is a Reaction card and a reaction window is open for the player,
   // show a "React" option instead of "Cast". Reaction windows specify which side
@@ -2506,8 +2512,8 @@ function showCardOptions(cardEl, cardData){
     reactionUI.defender === 'player'
   ) {
     opts.length = 0;
-    opts.push({ k: "react", label: "React" });
-    opts.push({ k: "pass", label: "Pass" });
+    opts.push({ k: "react", label: "React", desc:"Spend Aether to respond" });
+    opts.push({ k: "pass",  label: "Pass",  desc:"Decline this reaction" });
   }
   if (!opts.length) return;
 
@@ -2517,8 +2523,12 @@ function showCardOptions(cardEl, cardData){
   opts.forEach(o=>{
     const b = document.createElement("button");
     b.type="button";
-    b.className = `rune-btn act-${o.k}`;
-    b.textContent = o.label;
+    b.className = `rune-btn act-${o.k}` + (o.desc ? ' has-desc' : '');
+    if (o.desc) {
+      b.innerHTML = `<span class="rb-label">${o.label}</span><span class="rb-desc">${o.desc}</span>`;
+    } else {
+      b.textContent = o.label;
+    }
 
   b.addEventListener("click", async (ev)=>{
   ev.stopPropagation();
@@ -5205,6 +5215,165 @@ function ensureSafetyShape(s){
 let pipUIWired = false;
 
 
+/* ==========================================================
+   v17: GAME-FLOW CLARITY helpers (called from render())
+   ========================================================== */
+
+// 2. Empty slot affordance — pulse slots whose type matches a
+//    playable card in the player's hand (only on player's turn).
+function refreshSlotAffordance(){
+  const playerSlots = document.querySelectorAll('.row.player .slot');
+  playerSlots.forEach(s => s.classList.remove('slot-affordance-pulse'));
+
+  const onPlayerTurn = state?.activePlayer === 'player' && !state?.winner;
+  if (!onPlayerTurn) return;
+
+  const pub = serializePublic(state) || {};
+  const hand = pub.players?.player?.hand || [];
+
+  const canPlayAnySpell = hand.some(c => c.type === 'SPELL' && canPlaySpell(pub, c));
+  const canSetAnyGlyph  = hand.some(c => c.type === 'GLYPH' && canSetGlyph(pub, c));
+
+  if (canPlayAnySpell) {
+    document.querySelectorAll('.row.player .slot.spell:not(.has-card):not(.glyph)')
+      .forEach(s => s.classList.add('slot-affordance-pulse'));
+  }
+  if (canSetAnyGlyph) {
+    document.querySelectorAll('.row.player .slot.glyph:not(.has-card)')
+      .forEach(s => s.classList.add('slot-affordance-pulse'));
+  }
+}
+
+// 3. Win-condition tracker strip. Reads HP / Confluence / Dominion
+//    progress for both sides and updates the always-visible pill.
+//    Adds a `.near` class when a side is one step away from winning.
+function renderWinconStrip(){
+  const strip = document.getElementById('wincon-strip');
+  if (!strip) return;
+  const s = state;
+  if (!s?.players) return;
+
+  const sides = ['ai', 'player'];
+  sides.forEach(side => {
+    const p = s.players[side] || {};
+    const hp = p.vitality | 0;
+    const cf = (p.flowCardsAcquired | 0);
+    const dm = (p.greyEssence | 0);
+    const row = strip.querySelector(`.wc-row.wc-${side}`);
+    if (!row) return;
+    const hpEl = row.querySelector('.wc-hp .wc-val');
+    const cfEl = row.querySelector('.wc-cf .wc-val');
+    const dmEl = row.querySelector('.wc-dm .wc-val');
+    if (hpEl) hpEl.textContent = `${hp}`;
+    if (cfEl) {
+      cfEl.textContent = `${cf}/5`;
+      cfEl.classList.toggle('near', cf >= 4 && cf < 5);
+    }
+    if (dmEl) {
+      dmEl.textContent = `${dm}/10`;
+      dmEl.classList.toggle('near', dm >= 8 && dm < 10);
+    }
+    // HP "near" if at 1 — opponent is one shot from Ruin
+    if (hpEl) hpEl.classList.toggle('near', hp <= 1 && hp > 0);
+  });
+}
+
+// 4a. Trance unlock — diff against last-known level per side and
+//     fire a centered toast + portrait flash on transitions.
+const _lastTranceLevel = { player: 0, ai: 0 };
+function detectTranceUnlocks(){
+  ['player','ai'].forEach(side => {
+    const lvl = (state?.players?.[side]?.tranceLevel | 0);
+    const prev = _lastTranceLevel[side] | 0;
+    if (lvl > prev) triggerTranceUnlockMoment(side, lvl);
+    _lastTranceLevel[side] = lvl;
+  });
+}
+
+let _tranceToastEl = null, _tranceToastTimer = null;
+function triggerTranceUnlockMoment(side, lvl){
+  // Resolve weaver-specific tier label/desc.
+  const weaverName = state?.players?.[side]?.weaver?.name || '';
+  let tierName = `Stage ${lvl === 2 ? 'II' : 'I'}`;
+  let tierDesc = 'A new power has awakened.';
+  try {
+    const cfg = (typeof getTranceCfg === 'function') ? getTranceCfg(weaverName) : null;
+    const tier = cfg?.tiers?.[lvl - 1];
+    if (tier?.name) tierName = tier.name;
+    if (tier?.desc) tierDesc = tier.desc;
+  } catch {}
+
+  // Portrait flash on the affected side
+  const portraitEl = document.querySelector(
+    side === 'player' ? '.row.player .portrait' : '.row.ai .portrait'
+  );
+  if (portraitEl) {
+    portraitEl.classList.remove('trance-flash');
+    void portraitEl.offsetWidth;
+    portraitEl.classList.add('trance-flash');
+    setTimeout(() => portraitEl.classList.remove('trance-flash'), 950);
+  }
+
+  // Centered toast naming the unlocked tier
+  if (!_tranceToastEl) {
+    _tranceToastEl = document.createElement('div');
+    _tranceToastEl.id = 'trance-toast';
+    document.body.appendChild(_tranceToastEl);
+  }
+  const sideLabel = side === 'player' ? 'YOU' : 'OPPONENT';
+  _tranceToastEl.innerHTML =
+    `<div class="tt-tier">${sideLabel} · TRANCE ${lvl === 2 ? 'II' : 'I'}</div>` +
+    `<div class="tt-name">${tierName}</div>` +
+    `<div class="tt-desc">${tierDesc}</div>`;
+  _tranceToastEl.classList.add('show');
+  clearTimeout(_tranceToastTimer);
+  _tranceToastTimer = setTimeout(() => {
+    _tranceToastEl?.classList.remove('show');
+  }, 2200);
+
+  logLine(`✦ ${side} entered TRANCE ${lvl} — ${tierName}`);
+}
+
+// 4b. Hex applied — diff slot.hex state and fire a sided toast +
+//     red ring flash on the slot. No explicit hex event in
+//     GameLogic, so we detect via render-diff.
+const _lastHexState = { player: [false,false,false,false], ai: [false,false,false,false] };
+let _hexToastEl = null, _hexToastTimer = null;
+function detectHexApplied(){
+  ['player','ai'].forEach(side => {
+    const slots = state?.players?.[side]?.slots || [];
+    slots.forEach((slot, i) => {
+      const hexed = !!slot?.hex;
+      const prev = !!_lastHexState[side][i];
+      if (hexed && !prev) triggerHexAppliedMoment(side, i);
+      _lastHexState[side][i] = hexed;
+    });
+  });
+}
+function triggerHexAppliedMoment(side, slotIndex){
+  const rowSel = side === 'player' ? '.row.player' : '.row.ai';
+  const slotEl = document.querySelectorAll(`${rowSel} .slot.spell`)[slotIndex];
+  if (slotEl) {
+    slotEl.classList.remove('hex-applied-flash');
+    void slotEl.offsetWidth;
+    slotEl.classList.add('hex-applied-flash');
+    setTimeout(() => slotEl.classList.remove('hex-applied-flash'), 750);
+  }
+  if (!_hexToastEl) {
+    _hexToastEl = document.createElement('div');
+    _hexToastEl.id = 'hex-toast';
+    document.body.appendChild(_hexToastEl);
+  }
+  const who = side === 'player' ? 'Your' : 'Opponent’s';
+  _hexToastEl.textContent = `${who} slot was Hexed — disabled for 2 turns`;
+  _hexToastEl.classList.add('show');
+  clearTimeout(_hexToastTimer);
+  _hexToastTimer = setTimeout(() => {
+    _hexToastEl?.classList.remove('show');
+  }, 1700);
+}
+
+
 async function render(){
   const s = ensureSafetyShape(serializePublic(state) || {});
 
@@ -5249,7 +5418,13 @@ async function render(){
   renderTranceTrack('player');
   renderTranceTrack('ai');
   refreshPipAdvanceClasses();
-   
+
+  // v17 game-flow clarity: affordances, win-strip, pivot moments
+  refreshSlotAffordance();
+  renderWinconStrip();
+  detectTranceUnlocks();
+  detectHexApplied();
+
 
 
  
@@ -5709,6 +5884,74 @@ document.addEventListener("click", clearAllActionMenus);
 
 
 
+/* ---------- v17 wiring ---------- */
+
+// Wincon-strip click → toggle the small explainer popover.
+function wireWinconExplain(){
+  const strip   = document.getElementById('wincon-strip');
+  const explain = document.getElementById('wincon-explain');
+  if (!strip || !explain) return;
+  const close = explain.querySelector('.close');
+  strip.addEventListener('click', (ev) => {
+    ev.stopPropagation();
+    explain.classList.toggle('open');
+  });
+  close?.addEventListener('click', (ev) => {
+    ev.stopPropagation();
+    explain.classList.remove('open');
+  });
+  // Dismiss when clicking elsewhere
+  document.addEventListener('click', (ev) => {
+    if (!explain.contains(ev.target) && !strip.contains(ev.target)) {
+      explain.classList.remove('open');
+    }
+  });
+}
+
+// First-run welcome — show once based on localStorage flag, dismiss on
+// button click, and add a "Show welcome" entry in the menu sheet so
+// returning players can re-read.
+const WELCOME_FLAG = 'thegrey.welcomeSeen';
+function showWelcomeOverlay(){
+  const ov = document.getElementById('welcome-overlay');
+  if (!ov) return;
+  ov.dataset.shown = 'true';
+  ov.setAttribute('aria-hidden', 'false');
+}
+function hideWelcomeOverlay(){
+  const ov = document.getElementById('welcome-overlay');
+  if (!ov) return;
+  ov.dataset.shown = 'false';
+  ov.setAttribute('aria-hidden', 'true');
+}
+function wireWelcomeOverlay(){
+  const ov = document.getElementById('welcome-overlay');
+  const btn = document.getElementById('welcome-dismiss');
+  if (!ov || !btn) return;
+  btn.addEventListener('click', () => {
+    try { localStorage.setItem(WELCOME_FLAG, '1'); } catch {}
+    hideWelcomeOverlay();
+  });
+  let seen = '0';
+  try { seen = localStorage.getItem(WELCOME_FLAG) || '0'; } catch {}
+  if (seen !== '1') showWelcomeOverlay();
+
+  // Inject "Show welcome again" into the menu sheet, if present.
+  try {
+    const sheet = document.querySelector('.menu-sheet');
+    if (sheet && !sheet.querySelector('#welcome-replay-btn')) {
+      const btn2 = document.createElement('button');
+      btn2.id = 'welcome-replay-btn';
+      btn2.className = 'rune-btn';
+      btn2.textContent = 'Show welcome';
+      btn2.style.cssText = 'margin-top:8px; width:100%';
+      btn2.addEventListener('click', showWelcomeOverlay);
+      sheet.appendChild(btn2);
+    }
+  } catch {}
+}
+
+
 /* ---------- boot ---------- */
 document.addEventListener("DOMContentLoaded", async () => {
   ensureTopLeftUI();
@@ -5727,6 +5970,10 @@ document.addEventListener("DOMContentLoaded", async () => {
   ensureReactionStyles();
   ensureShuffleStyles();
   ensureCardMotionStyles();
+
+  // v17: wire wincon-strip explainer + first-run welcome overlay
+  wireWinconExplain();
+  wireWelcomeOverlay();
 
 
 // 🔒 Gate check

--- a/styles.css
+++ b/styles.css
@@ -2529,3 +2529,206 @@ body[data-active-side="ai"]     #turn-badge::before {
   box-shadow: 0 6px 14px rgba(0,0,0,.5);
 }
 #ai-toast.show { opacity: 1; transform: translateY(0); }
+
+
+/* ==========================================================
+   v17: GAME-FLOW CLARITY pass
+   1. Action menu button subtitles
+   2. Empty slot affordance pulse
+   3. Win-condition tracker strip
+   4. Trance + Hex pivot moments (toast + flash)
+   5. First-run welcome overlay
+   ========================================================== */
+
+/* 1. Two-line action buttons (Play / Send to a Spell Slot, etc.) */
+.rune-btn.has-desc {
+  display: inline-flex; flex-direction: column; align-items: center;
+  justify-content: center; line-height: 1.1; gap: 2px;
+  padding-top: 8px; padding-bottom: 8px;
+}
+.rune-btn .rb-label { font-weight: 700; font-size: 1em; }
+.rune-btn .rb-desc  { font-weight: 500; font-size: .62em; opacity: .82;
+                      letter-spacing: .02em; max-width: 22ch;
+                      text-align: center; white-space: nowrap; }
+body.mobile-landscape .action-pop .rune-btn.has-desc,
+body.mobile-portrait  .action-pop .rune-btn.has-desc{
+  padding: 10px 14px; min-width: 110px;
+}
+body.mobile-landscape .action-pop .rune-btn.has-desc .rb-desc,
+body.mobile-portrait  .action-pop .rune-btn.has-desc .rb-desc{
+  font-size: .58em;
+}
+
+/* 2. Empty slot affordance: gentle gold pulse on slots that can receive
+   a hand card on the player's turn. The .has-card guard ensures filled
+   slots never pulse; turn-end clears the class via JS. */
+@keyframes slotAffordancePulse {
+  0%, 100% {
+    box-shadow: 0 0 0 0 rgba(198,165,106,0),
+                inset 0 0 0 0 rgba(198,165,106,0);
+  }
+  50% {
+    box-shadow: 0 0 0 5px rgba(198,165,106,.18),
+                inset 0 0 16px rgba(198,165,106,.14);
+  }
+}
+.slot.slot-affordance-pulse:not(.has-card){
+  border-color: rgba(198,165,106,.55) !important;
+  animation: slotAffordancePulse 1.6s ease-in-out infinite;
+}
+
+/* 3. Win-condition tracker strip — always visible, both sides.
+   Top-fixed pill with two rows (ai over player). */
+#wincon-strip {
+  position: fixed; top: 4px; right: 8px;
+  display: flex; flex-direction: column; gap: 3px;
+  background: rgba(20,16,12,.78);
+  border: 1px solid #4a3d2f; border-radius: 10px;
+  padding: 4px 8px;
+  z-index: 30; pointer-events: auto;
+  font-size: .66rem; font-weight: 600; letter-spacing: .03em;
+  color: #d6c8a4;
+  box-shadow: 0 4px 10px rgba(0,0,0,.45);
+}
+#wincon-strip .wc-row {
+  display: flex; gap: 9px; align-items: center; white-space: nowrap;
+}
+#wincon-strip .wc-row.wc-ai     { color: #d97a7a; }
+#wincon-strip .wc-row.wc-player { color: #c6a56a; }
+#wincon-strip .wc-row > span {
+  display: inline-flex; align-items: center; gap: 3px;
+}
+#wincon-strip .wc-val.near {
+  color: #ffd87a; text-shadow: 0 0 6px rgba(255,216,122,.55);
+}
+#wincon-strip .wc-row .wc-label {
+  font-size: .58rem; opacity: .7; text-transform: uppercase;
+  letter-spacing: .08em;
+}
+#wincon-strip .wc-icon {
+  width: 9px; height: 9px; display: inline-block;
+}
+/* On portrait, move to top-left so it doesn't fight the menu hamburger.
+   The turn-badge sits center-top; this sits below it. */
+body.mobile-portrait #wincon-strip,
+body.mobile-landscape #wincon-strip {
+  top: 26px; right: 6px; font-size: .6rem; padding: 3px 6px;
+}
+/* Tap target: open a small explainer popover */
+#wincon-explain {
+  position: fixed; top: 78px; right: 8px; max-width: 240px;
+  background: rgba(20,16,12,.96); border: 1px solid #6a5840;
+  border-radius: 8px; padding: 10px 12px; z-index: 5500;
+  font-size: .72rem; color: #e7dcc3; line-height: 1.35;
+  box-shadow: 0 8px 18px rgba(0,0,0,.55); display: none;
+  pointer-events: auto;
+}
+#wincon-explain.open { display: block; }
+#wincon-explain h4 { margin: 0 0 4px; font-size: .82rem; color: #c6a56a; }
+#wincon-explain p  { margin: 0 0 6px; }
+#wincon-explain .close {
+  position: absolute; top: 4px; right: 6px;
+  background: transparent; border: 0; color: #8a7a5a;
+  font-size: .9rem; cursor: pointer;
+}
+
+/* 4a. Trance unlock — centered toast with portrait flash */
+#trance-toast {
+  position: fixed; left: 50%; top: 36%; transform: translate(-50%,-50%) scale(.92);
+  background: linear-gradient(180deg, rgba(40,28,12,.96), rgba(28,20,10,.96));
+  border: 1px solid #c6a56a; border-radius: 14px;
+  padding: 14px 22px; min-width: 220px; max-width: 78vw;
+  text-align: center; color: #f1e3bf;
+  box-shadow: 0 0 40px rgba(198,165,106,.55), 0 12px 26px rgba(0,0,0,.7);
+  z-index: 6000; pointer-events: none; opacity: 0;
+  transition: opacity .25s ease, transform .25s ease;
+}
+#trance-toast.show { opacity: 1; transform: translate(-50%,-50%) scale(1); }
+#trance-toast .tt-tier {
+  font-size: .7rem; font-weight: 700; letter-spacing: .15em;
+  color: #c6a56a; text-transform: uppercase;
+}
+#trance-toast .tt-name { font-size: 1.05rem; font-weight: 700; margin-top: 2px; }
+#trance-toast .tt-desc {
+  font-size: .78rem; opacity: .9; margin-top: 4px; line-height: 1.3;
+}
+@keyframes trancePortraitFlash {
+  0%   { box-shadow: 0 0 0 0 rgba(198,165,106,0); }
+  35%  { box-shadow: 0 0 0 14px rgba(198,165,106,.7),
+                      0 0 38px 8px rgba(198,165,106,.55); }
+  100% { box-shadow: 0 0 0 22px rgba(198,165,106,0); }
+}
+.trance-flash {
+  animation: trancePortraitFlash 900ms ease-out;
+  border-radius: 50%;
+}
+
+/* 4b. Hex applied — red expanding ring on slot + sided toast */
+@keyframes hexAppliedFlash {
+  0%   { box-shadow: 0 0 0 0 rgba(217,122,122,0); }
+  30%  { box-shadow: 0 0 0 6px rgba(217,122,122,.7),
+                     inset 0 0 18px rgba(217,122,122,.4); }
+  100% { box-shadow: 0 0 0 14px rgba(217,122,122,0); }
+}
+.slot.hex-applied-flash { animation: hexAppliedFlash 700ms ease-out; }
+#hex-toast {
+  position: fixed; left: 50%; top: 30%; transform: translateX(-50%);
+  background: rgba(20,8,8,.94); border: 1px solid #8a3a3a;
+  color: #f1c1c1; padding: 8px 14px; border-radius: 10px;
+  font-size: .78rem; font-weight: 600;
+  z-index: 5500; pointer-events: none;
+  opacity: 0; transition: opacity .18s ease;
+  box-shadow: 0 8px 18px rgba(0,0,0,.55);
+}
+#hex-toast.show { opacity: 1; }
+
+/* 5. First-run welcome overlay */
+#welcome-overlay {
+  position: fixed; inset: 0; z-index: 7000;
+  background: radial-gradient(ellipse at center,
+    rgba(0,0,0,.88) 0%, rgba(0,0,0,.96) 100%);
+  display: none; align-items: center; justify-content: center;
+  padding: 16px;
+}
+#welcome-overlay[data-shown="true"] { display: flex; }
+#welcome-overlay .welcome-panel {
+  background: linear-gradient(180deg, #221a10, #14100a);
+  border: 1px solid #6a5840; border-radius: 16px;
+  padding: 22px 22px 18px;
+  max-width: 380px; max-height: 86dvh; overflow-y: auto;
+  color: #e7dcc3;
+  box-shadow: 0 0 50px rgba(198,165,106,.4),
+              0 16px 32px rgba(0,0,0,.7);
+}
+#welcome-overlay h2 {
+  margin: 0 0 4px; font-size: 1.5rem; color: #c6a56a;
+  letter-spacing: .04em; text-align: center;
+}
+#welcome-overlay .welcome-tagline {
+  margin: 0 0 14px; text-align: center;
+  font-size: .82rem; opacity: .85; font-style: italic;
+}
+#welcome-overlay h3 {
+  margin: 12px 0 6px; font-size: .8rem; color: #c6a56a;
+  letter-spacing: .12em; text-transform: uppercase;
+}
+#welcome-overlay .welcome-paths {
+  list-style: none; padding: 0; margin: 0 0 12px;
+  font-size: .82rem; line-height: 1.5;
+}
+#welcome-overlay .welcome-paths li {
+  padding: 6px 10px; border-left: 2px solid #6a5840;
+  margin-bottom: 4px; background: rgba(40,28,12,.45);
+}
+#welcome-overlay .welcome-paths b { color: #ffd87a; margin-right: 4px; }
+#welcome-overlay .welcome-tip {
+  font-size: .76rem; opacity: .8; margin: 8px 0 14px; line-height: 1.45;
+}
+#welcome-overlay #welcome-dismiss {
+  display: block; width: 100%; padding: 12px;
+  font-size: .95rem; font-weight: 700; letter-spacing: .08em;
+  background: linear-gradient(180deg, #c6a56a, #8c6b3d);
+  color: #1a1208; border: 0; border-radius: 10px; cursor: pointer;
+  text-transform: uppercase;
+}
+#welcome-overlay #welcome-dismiss:active { transform: translateY(1px); }


### PR DESCRIPTION
User: *"Relook at the game play and game flow. Right now it's a bit broken, unfun, and unclear what's going on or what to do."*

Three Explore agents surveyed the game and converged on the same five critical UX gaps. v17 closes all of them. **Approved scope: 5 items.**

## 1. Action menu subtitles
`showCardOptions()` (`index.js:2483`) was rendering unlabeled verbs — Play / Set / Channel / Cast — with no explanation. Each option now carries a `desc` and renders as a two-line button:

| Verb | Subtitle |
|---|---|
| Play | Send to a Spell Slot |
| Set / Replace | Place as Glyph (passive) / Swap your Glyph (passive) |
| Cast | Resolve immediately |
| Channel / Discard | Discard for +N Æ this turn / Send to discard pile |
| React / Pass | Spend Aether to respond / Decline this reaction |

New CSS `.rune-btn.has-desc` flex-column with `.rb-label` + `.rb-desc`.

## 2. Empty slot affordance pulse
On the player's turn, empty Spell Slots gold-pulse when the player has any playable SPELL in hand; same for the Glyph slot vs GLYPHs. Filled slots never pulse (`:not(.has-card)` guard, verified via `index.js:2954, 3017`). Stops on AI's turn. New `slotAffordancePulse` keyframe.

## 3. Win-condition tracker strip (#wincon-strip)
**Always-visible** pill on every viewport showing both sides':

```
♥ HP / ◇ Confluence (X/5) / ▲ Dominion (X/10)
```

`.near` glow when one step from winning. Tap → small explainer popover defining the 3 paths. Win conditions are no longer invisible until the pending-win banner fires.

## 4. Trance + Hex pivot moments
**Trance unlock** (`detectTranceUnlocks`): module-level `_lastTranceLevel` cache diff'd in `render()`. When a side's `tranceLevel` increases, fires a centered `#trance-toast` naming the unlocked tier (read from existing `WEAVER_TRANCE` table at `index.js:3692`) + gold `.trance-flash` ring on the portrait. Players now SEE their weaver gain a power.

**Hex applied** (`detectHexApplied`): no explicit hex event in GameLogic, so `_lastHexState[side][slotIdx]` is diff'd in `render()`. New hexes trigger a red `.hex-applied-flash` ring on the affected slot + sided toast: *"Your slot was Hexed — disabled for 2 turns"*. No more stealth penalty.

## 5. First-run welcome overlay (#welcome-overlay)
One-time modal explaining the **3 win paths** + the **core turn loop**. Persisted via `localStorage('thegrey.welcomeSeen')`. Menu sheet gets a "Show welcome" button so returning players can re-read.

## Files
- `index.html` — `#wincon-strip`, `#wincon-explain`, `#welcome-overlay` markup; cache-bust to `mlv17-20260509`
- `index.js` ~2483 — action menu `desc` + two-line render
- `index.js` ~5215 — six new helpers (`refreshSlotAffordance`, `renderWinconStrip`, `detectTranceUnlocks`, `triggerTranceUnlockMoment`, `detectHexApplied`, `triggerHexAppliedMoment`)
- `index.js` ~5260 — wired into `render()` after `refreshPipAdvanceClasses()`
- `index.js` ~5887 — `wireWinconExplain` + `wireWelcomeOverlay` + menu replay button
- `styles.css` — full v17 block at end (button subtitle, slot pulse, wincon strip + explainer, trance toast + portrait flash, hex flash + toast, welcome overlay panel)

Single squashable commit `6e62353`.

---
_Generated by [Claude Code](https://claude.ai/code/session_01C1TYVtozydzcqvzpY15HMA)_