### PR TITLE
v19: mobile drag feel (peek-suppress, source-dim, haptic, snap) + slim HP bar

### DIFF
--- a/index.html
+++ b/index.html
@@ -5,7 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <title>The Grey — board</title>
   <link href="https://fonts.googleapis.com/css2?family=Cormorant+Garamond:wght@400;600&family=Crimson+Text:wght@600&display=swap" rel="stylesheet">
-  <link rel="stylesheet" href="./styles.css?v=mlv18-20260509" />
+  <link rel="stylesheet" href="./styles.css?v=mlv19-20260509" />
 </head>
 <body id="board" class="theme-dark parchment">
 
@@ -178,7 +178,7 @@
     </div>
   </div>
 
-  <script type="module" src="./index.js?v=mlv18-20260509"></script>
+  <script type="module" src="./index.js?v=mlv19-20260509"></script>
 </body>
 
 </html>

--- a/index.js
+++ b/index.js
@@ -2053,17 +2053,31 @@ function heartSVG({ filled = true, size = 36 } = {}) {
  * Render hearts as "containers": show `maxHearts` outlines,
  * with the first `hp` hearts filled. Defaults to 12 max.
  */
+// v19: replaced 12-icon SVG row with a slim continuous HP bar.
+// 12 tiny 12×12px hearts on mobile portrait (~156px row) became a
+// "gray blur" — the wincon strip's numeric ♥ was carrying all the
+// at-a-glance load while the heart row was just visual noise. The
+// new bar is one icon + a thin 7px-tall track + a numeric value,
+// color-tiered green→amber→red as HP drops.
 function renderHearts(el, hp = 12, maxHearts = 12) {
   if (!el) return;
-  const cur = Math.max(0, hp | 0);
-  const max = Math.max(cur, maxHearts | 0) || 12;
-
-  const nodes = [];
-  for (let i = 0; i < max; i++) {
-    const filled = i < cur;
-    nodes.push(`<span class="heart">${heartSVG({ filled, size: 36 })}</span>`);
-  }
-  el.innerHTML = nodes.join("");
+  const max = Math.max(1, maxHearts | 0);
+  const cur = Math.max(0, Math.min(hp | 0, max));
+  const pct = (cur / max) * 100;
+  let tier = 'high';
+  if (pct <= 33) tier = 'low';
+  else if (pct <= 66) tier = 'mid';
+  el.classList.remove('hp-tier-high','hp-tier-mid','hp-tier-low');
+  el.classList.add(`hp-tier-${tier}`);
+  el.classList.add('hp-bar-host');
+  el.innerHTML =
+    `<span class="hp-icon" aria-hidden="true">♥</span>` +
+    `<div class="hp-bar-track" role="progressbar" ` +
+      `aria-valuemin="0" aria-valuemax="${max}" aria-valuenow="${cur}" ` +
+      `aria-label="vitality ${cur} of ${max}">` +
+      `<div class="hp-bar-fill" style="width:${pct.toFixed(1)}%"></div>` +
+    `</div>` +
+    `<span class="hp-num">${cur}</span>`;
 }
 
 
@@ -2201,7 +2215,16 @@ function fillCardShell(div, data){ if (div) div.innerHTML = cardShellHTML(data);
 
 /* centered hover + press-and-hhold preview */
 let longPressTimer=null, pressStart={x:0,y:0};
-const LONG_PRESS_MS=350, MOVE_CANCEL_PX=8;
+const LONG_PRESS_MS=500, MOVE_CANCEL_PX=8;
+
+// v19: expose so the drag handler can suppress peek the moment a
+// drag-eligible touch lands. Without this, a 350-500ms hold would
+// pop the peek overlay over the very card being dragged.
+function cancelPeek(){
+  if (longPressTimer) { clearTimeout(longPressTimer); longPressTimer = null; }
+  peekEl?.classList.remove("show");
+}
+
 function attachPeekAndZoom(el, data){
   if (peekEl){
     el.addEventListener("mouseenter", ()=>{ fillCardShell(peekEl, data); peekEl.classList.add("show"); });
@@ -2742,46 +2765,97 @@ function wireDesktopDrag(el, data){
      (focus + showCardOptions). preventDefault on a tap suppresses the
      synthesized click that would otherwise re-trigger showCardOptions
      through wireDesktopDrag's click listener. */
+// v19: navigator.vibrate wrapper. Android Chrome supports it; iOS
+// Safari ignores it silently. The try/catch handles the rare case
+// where vibrate is blocked by user-activation rules.
+function buzz(p){ try { navigator.vibrate?.(p); } catch {} }
+
+// v19: forgiving drop-target lookup. Pixel-perfect elementFromPoint
+// felt brittle on phones — release ~25px off a slot and the drop
+// would silently fail. Now we fall back to scanning valid empty
+// slots within snapPx of the touch point and pick the closest one.
+function findDropTargetWithSnap(x, y, type, snapPx = 36){
+  const elUnder = document.elementFromPoint(x, y);
+  const direct = findValidDropTarget(elUnder, type);
+  if (direct) return direct;
+  const sel = (type === 'GLYPH')
+    ? '.row.player .slot.glyph:not(.has-card)'
+    : '.row.player .slot.spell:not(.has-card):not(.glyph)';
+  const slots = document.querySelectorAll(sel);
+  let best = null, bestDist = snapPx + 1;
+  slots.forEach(s => {
+    const r = s.getBoundingClientRect();
+    const cx = (r.left + r.right) / 2;
+    const cy = (r.top + r.bottom) / 2;
+    const d = Math.hypot(x - cx, y - cy);
+    if (d < bestDist) { bestDist = d; best = s; }
+  });
+  return best;
+}
+
 function wireTouchDrag(el, data){
   let dragging=false, ghost=null, currentHover=null;
   let touchStartTime=0, touchStartX=0, touchStartY=0, primed=false;
+  let _moveRaf=0, _moveLastXY=null;
   const DRAG_THRESHOLD_PX = 8;
   const TAP_MAX_MS = 300;
 
   const beginDrag = (x, y)=>{
+    cancelPeek();                       // v19: kill any pending peek
     clearAllActionMenus();
     dragging = true; markDropTargets(data.type, true);
+    el.classList.add("dragging-source"); // v19: dim the card in hand
     ghost = el.cloneNode(true);
     ghost.style.position="fixed"; ghost.style.left="0"; ghost.style.top="0";
     ghost.style.pointerEvents="none"; ghost.style.transform="translate(-9999px,-9999px)";
     ghost.style.zIndex="99999"; ghost.classList.add("dragging");
     document.body.appendChild(ghost);
-    moveDrag(x, y);
+    buzz(15);                            // v19: tick on lift
+    moveDragRAF(x, y);
   };
   const moveDrag = (x,y)=>{
     if (!dragging || !ghost) return;
     ghost.style.transform = `translate(${x-ghost.clientWidth/2}px, ${y-ghost.clientHeight*0.9}px) rotate(6deg)`;
-    const elUnder = document.elementFromPoint(x,y);
-    const hoverTarget = findValidDropTarget(elUnder, data.type);
+    const hoverTarget = findDropTargetWithSnap(x, y, data.type, 36);
     if (hoverTarget !== currentHover){
       currentHover?.classList.remove("drag-over");
       currentHover = hoverTarget; currentHover?.classList.add("drag-over");
     }
   };
+  // v19: rAF-coalesced wrapper so we do at most one full moveDrag
+  // (transform + elementFromPoint + class toggle) per animation frame
+  // even if touchmove fires every pixel.
+  const moveDragRAF = (x, y) => {
+    _moveLastXY = { x, y };
+    if (_moveRaf) return;
+    _moveRaf = requestAnimationFrame(() => {
+      _moveRaf = 0;
+      if (_moveLastXY) moveDrag(_moveLastXY.x, _moveLastXY.y);
+    });
+  };
   const finishDrag = (x, y)=>{
     if (!dragging) return; dragging=false;
-    const elUnder = document.elementFromPoint(x, y);
-    const target = findValidDropTarget(elUnder, data.type);
+    const target = findDropTargetWithSnap(x, y, data.type, 36);
     currentHover?.classList.remove("drag-over"); currentHover=null;
     markDropTargets(data.type, false);
+    el.classList.remove("dragging-source");
     ghost?.remove(); ghost=null;
-    if (target) applyDrop(target, el.dataset.cardId, data.type);
+    if (_moveRaf) { cancelAnimationFrame(_moveRaf); _moveRaf = 0; }
+    if (target) {
+      buzz([8, 40, 8]);                  // v19: landed pattern
+      applyDrop(target, el.dataset.cardId, data.type);
+    } else {
+      buzz(60);                          // v19: thud on miss
+    }
   };
   const cancelDrag = ()=>{
     if (!dragging) return; dragging=false;
     currentHover?.classList.remove("drag-over"); currentHover=null;
     markDropTargets(data.type, false);
+    el.classList.remove("dragging-source");
     ghost?.remove(); ghost=null;
+    if (_moveRaf) { cancelAnimationFrame(_moveRaf); _moveRaf = 0; }
+    buzz(60);
   };
   const onTap = ()=>{
     Array.from(handEl.children).forEach(n=> n.classList.remove("is-focus"));
@@ -2801,6 +2875,11 @@ function wireTouchDrag(el, data){
     primed = true;
     touchStartTime = performance.now();
     touchStartX = t.clientX; touchStartY = t.clientY;
+    // v19: as soon as a drag-eligible touch lands on a hand card,
+    // suppress the long-press peek timer. Peek still fires if the
+    // user holds COMPLETELY STILL through the 8px threshold and the
+    // 500ms long-press window — but any drag-intent kills it early.
+    cancelPeek();
   }, {passive:true});
 
   el.addEventListener("touchmove", (ev)=>{
@@ -2814,7 +2893,7 @@ function wireTouchDrag(el, data){
       }
       return;
     }
-    moveDrag(t.clientX, t.clientY);
+    moveDragRAF(t.clientX, t.clientY);
     ev.preventDefault();
   }, {passive:false});
 

--- a/styles.css
+++ b/styles.css
@@ -2759,3 +2759,100 @@ body.player-already-bought #wincon-strip::after {
   text-transform: uppercase;
   opacity: .85;
 }
+
+
+/* ==========================================================
+   v19: MOBILE DRAG FEEL + HP BAR
+   - .card.dragging-source dims source while ghost flies
+   - Stronger .slot.drag-over so snap targets are obvious
+   - .hp-bar-host replaces the 12-heart row (one icon + slim
+     bar + numeric, color-tiered)
+   ========================================================== */
+
+/* Dim the original card while the ghost is being dragged so the
+   user clearly sees which copy is "in flight." Pointer-events off
+   so clicks don't go to the husk. */
+.card.dragging-source {
+  opacity: .22 !important;
+  filter: grayscale(.4);
+  transition: opacity .1s ease, filter .1s ease;
+  pointer-events: none;
+}
+
+/* Stronger drop-target highlight. With the new 36px snap zone,
+   slots can light up even when the finger is OFF them; the
+   stronger glow makes "this is where it'll land" unmistakable. */
+.slot.drag-over {
+  outline: 2px solid var(--aether) !important;
+  outline-offset: 2px;
+  box-shadow: 0 0 0 4px rgba(126,182,255,.25),
+              inset 0 0 18px rgba(126,182,255,.18) !important;
+  transition: box-shadow .12s ease, outline-color .12s ease;
+}
+
+/* Slim HP bar — replaces the 12-icon row inside #player-hearts /
+   #ai-hearts. Same DOM containers, new contents. */
+.hp-bar-host {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  font-variant-numeric: tabular-nums;
+}
+.hp-bar-host .hp-icon {
+  font-size: .95em;
+  line-height: 1;
+}
+.hp-bar-host .hp-bar-track {
+  position: relative;
+  flex: 1;
+  max-width: 86px;
+  height: 7px;
+  border-radius: 4px;
+  background: rgba(40,28,12,.6);
+  border: 1px solid rgba(106,90,64,.6);
+  overflow: hidden;
+  box-shadow: inset 0 1px 2px rgba(0,0,0,.4);
+}
+.hp-bar-host .hp-bar-fill {
+  height: 100%;
+  transition: width .25s ease, background .25s ease;
+  background: linear-gradient(90deg, #c44 0%, #d76 100%);
+}
+.hp-tier-high .hp-bar-fill { background: linear-gradient(90deg,#7eb265,#a4cc8a); }
+.hp-tier-mid  .hp-bar-fill { background: linear-gradient(90deg,#c69a4a,#e7c876); }
+.hp-tier-low  .hp-bar-fill { background: linear-gradient(90deg,#c44a4a,#e07a7a); }
+.hp-bar-host .hp-num {
+  font-size: .82em;
+  font-weight: 700;
+  color: #d6c8a4;
+  min-width: 1.6ch;
+  text-align: right;
+}
+
+/* Side tinting: gold for player, red for AI */
+.row.ai     .hp-bar-host .hp-icon,
+.row.ai     .hp-bar-host .hp-num { color: #d97a7a; }
+.row.player .hp-bar-host .hp-icon,
+.row.player .hp-bar-host .hp-num { color: #c6a56a; }
+
+/* Mobile compact: smaller bar so the chip footprint stays tight */
+body.mobile-portrait  .hp-bar-host .hp-bar-track,
+body.mobile-landscape .hp-bar-host .hp-bar-track {
+  max-width: 70px;
+  height: 6px;
+}
+body.mobile-portrait  .hp-bar-host,
+body.mobile-landscape .hp-bar-host {
+  font-size: .9em;
+  gap: 3px;
+}
+
+/* The container (#player-hearts / #ai-hearts) was previously
+   styled as a flex row of 12 hearts. Reset its layout so the new
+   .hp-bar-host renders cleanly inside. */
+#player-hearts, #ai-hearts {
+  display: flex;
+  align-items: center;
+  flex-wrap: nowrap;
+  min-width: 0;
+}


### PR DESCRIPTION
User: *"Click and drag doesn't feel good on mobile. Health information is redundant and/or unclear."*

Two parallel Explore agents diagnosed both. v19 ships the user's full chosen scope: **all 4 drag fixes** + **slim HP bar on chip + keep numeric in wincon strip**.

## Drag fixes

The drag audit ranked 5 issues; all 5 addressed.

### 1. Suppress peek when dragging
The 350ms long-press peek was firing *during* drag attempts — peek opens, blocks the view, drag begins underneath. Two changes:
- `LONG_PRESS_MS: 350 → 500` (less aggressive)
- New module-level `cancelPeek()` called from `wireTouchDrag`'s `touchstart` AND from `beginDrag`. Any drag-eligible touch on a hand card kills the peek timer immediately. Peek now requires holding *completely still* for 500ms — drag at 8px movement always wins.

### 2. Hide source card while dragging
`beginDrag` adds `.dragging-source` to the source el; `finishDrag`/`cancelDrag` remove it. CSS dims source to 22% opacity + grayscale + `pointer-events: none`. No more visual doubling between source and ghost on tiny portrait cards.

### 3. Haptic feedback
New `buzz(p)` wrapper around `navigator.vibrate`. Three moments:
- 15ms tick on lift
- `[8,40,8]` landed pattern on successful drop
- 60ms thud on miss / cancel

Android Chrome supports; iOS Safari ignores silently. `try/catch` for the rare user-activation block case.

### 4. Forgiving drop tolerance + snap preview
New `findDropTargetWithSnap(x, y, type, snapPx=36)` replaces the pixel-perfect `elementFromPoint` lookups in both `moveDrag` and `finishDrag`. If no direct hit, scan all valid empty slots within 36px of the touch point and pick the closest center.

Snap preview is implicit: snap-found slot still gets `.drag-over`, so the user sees where the card will land before releasing. CSS strengthened — `.slot.drag-over` now has 2px outline + 4px outer glow + inset cyan tint, unmistakable.

### 5. rAF throttle (free perf win, not gated on user choice)
`moveDragRAF` coalesces every-pixel `touchmove` into at most one full update per frame. Cleaned up on finish/cancel. Replaces direct `moveDrag` callsites in `beginDrag` and the touchmove handler.

## HP display

`renderHearts()` was rendering 12 SVG hearts that became a 12×12px "gray blur" on portrait phones — duplicating the wincon strip's numeric `♥`.

Same function signature, new body: slim continuous HP bar with one heart icon, a 7px-tall track, a numeric value, and a color tier (green > 66% / amber 33–66% / red < 33%). Player tinted gold; AI tinted red.

Wincon strip numeric `♥` stays as the global at-a-glance tracker alongside Confluence + Dominion — different form, no redundancy.

## Files
- `index.js` ~2056 — `renderHearts()` rewritten
- `index.js` ~2204 — `LONG_PRESS_MS = 500`; `cancelPeek()` exposed
- `index.js` ~2745 — `wireTouchDrag` + new `buzz()` and `findDropTargetWithSnap()` helpers
- `styles.css` (append) — `.card.dragging-source`, stronger `.slot.drag-over`, `.hp-bar-host` + tier classes
- `index.html` — cache-bust `mlv19-20260509`

Single squashable commit `a30be89`.

---
_Generated by [Claude Code](https://claude.ai/code/session_01C1TYVtozydzcqvzpY15HMA)_