### PR TITLE
v20: wincon rails between rows + chip cleanup

### DIFF
--- a/index.html
+++ b/index.html
@@ -5,7 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <title>The Grey — board</title>
   <link href="https://fonts.googleapis.com/css2?family=Cormorant+Garamond:wght@400;600&family=Crimson+Text:wght@600&display=swap" rel="stylesheet">
-  <link rel="stylesheet" href="./styles.css?v=mlv19-20260509" />
+  <link rel="stylesheet" href="./styles.css?v=mlv20-20260509" />
 </head>
 <body id="board" class="theme-dark parchment">
 
@@ -25,36 +25,8 @@
   <div id="turn-badge" aria-live="polite"></div>
 
   <!-- v17: always-visible win-condition tracker (both sides) -->
-  <div id="wincon-strip" aria-label="Win condition progress">
-    <div class="wc-row wc-ai" data-side="ai">
-      <span class="wc-hp" title="Vitality (Ruin at 0)">
-        <span class="wc-icon" aria-hidden="true">♥</span>
-        <span class="wc-val">12</span>
-      </span>
-      <span class="wc-cf" title="Confluence: buy 7 from Aether Flow">
-        <span class="wc-icon" aria-hidden="true">◇</span>
-        <span class="wc-val">0/7</span>
-      </span>
-      <span class="wc-dm" title="Dominion: channel 10+ Aether">
-        <span class="wc-icon" aria-hidden="true">▲</span>
-        <span class="wc-val">0/10</span>
-      </span>
-    </div>
-    <div class="wc-row wc-player" data-side="player">
-      <span class="wc-hp" title="Vitality (Ruin at 0)">
-        <span class="wc-icon" aria-hidden="true">♥</span>
-        <span class="wc-val">12</span>
-      </span>
-      <span class="wc-cf" title="Confluence: buy 7 from Aether Flow">
-        <span class="wc-icon" aria-hidden="true">◇</span>
-        <span class="wc-val">0/7</span>
-      </span>
-      <span class="wc-dm" title="Dominion: channel 10+ Aether">
-        <span class="wc-icon" aria-hidden="true">▲</span>
-        <span class="wc-val">0/10</span>
-      </span>
-    </div>
-  </div>
+  <!-- v20: #wincon-strip removed. Per-side .wincon-rail elements now
+       live inside #board-grid between the rows. -->
   <div id="wincon-explain" role="dialog" aria-hidden="true">
     <button class="close" aria-label="Close">×</button>
     <h4>Three paths to victory</h4>
@@ -94,9 +66,9 @@
       <figure class="portrait">
         <img id="ai-portrait" src="" alt="Opponent" />
         <figcaption id="ai-name">Morr, Gravecurrent Binder</figcaption>
-        <div class="hearts" id="ai-hearts"></div>
+        <!-- v20: HP bar moved off the chip onto the AI wincon rail below. -->
        <div class="trance" data-side="ai">
- 
+
 </div>
 
 
@@ -117,7 +89,14 @@
   </div>
 </div>
 
-      
+
+    </section>
+
+    <!-- v20: AI win-condition rail (between AI slots and the market) -->
+    <section class="wincon-rail wc-ai" data-side="ai" aria-label="Opponent win conditions">
+      <div class="wcr-host hp"  id="ai-wcr-hp"></div>
+      <div class="wcr-host cf"  id="ai-wcr-cf"></div>
+      <div class="wcr-host dom" id="ai-wcr-dom"></div>
     </section>
 
     <!-- FLOW (center) -->
@@ -130,13 +109,20 @@
       </div>
     </section>
 
+    <!-- v20: Player win-condition rail (between the market and player slots) -->
+    <section class="wincon-rail wc-player" data-side="player" aria-label="Your win conditions">
+      <div class="wcr-host hp"  id="player-wcr-hp"></div>
+      <div class="wcr-host cf"  id="player-wcr-cf"></div>
+      <div class="wcr-host dom" id="player-wcr-dom"></div>
+    </section>
+
     <!-- PLAYER (bottom) -->
     <section class="row player">
       <div id="player-slots" class="slot-row" aria-label="Player slots"></div>
       <figure class="portrait">
          <img id="player-portrait" src="" alt="Player" />
         <figcaption id="player-name">Aria, Runesurge Adept</figcaption>
-        <div class="hearts" id="player-hearts"></div>
+        <!-- v20: HP bar moved off the chip onto the player wincon rail above. -->
         <div class="trance" data-side="player">
   
 </div>
@@ -178,7 +164,7 @@
     </div>
   </div>
 
-  <script type="module" src="./index.js?v=mlv19-20260509"></script>
+  <script type="module" src="./index.js?v=mlv20-20260509"></script>
 </body>
 
 </html>

--- a/index.js
+++ b/index.js
@@ -545,8 +545,14 @@ function seedFlowToFiveOnBoot() {
 
 
 
+// v20: the chip-mounted #player-hearts / #ai-hearts elements are gone;
+// the HP bar now lives on the wincon rail (#player-wcr-hp / #ai-wcr-hp).
+// VFX anchors that fired on the hearts node now point at the rail host
+// (or the portrait as a final fallback) so damage shards/cracks/floaters
+// still visually originate near the HP indicator.
 function heartsElFor(side) {
-  return document.getElementById(side === 'player' ? 'player-hearts' : 'ai-hearts');
+  return document.getElementById(side === 'player' ? 'player-wcr-hp' : 'ai-wcr-hp')
+      || document.querySelector(side === 'player' ? '.row.player .portrait' : '.row.ai .portrait');
 }
 
 function animateDamage(side, amount = 1) {
@@ -580,8 +586,8 @@ function animateDamage(side, amount = 1) {
   host.appendChild(crack);
   crack.addEventListener('animationend', () => crack.remove(), { once:true });
 
-  // radial shards bursting from the heart row center
-  const hearts = document.getElementById(side === 'player' ? 'player-hearts' : 'ai-hearts');
+  // radial shards bursting from the HP bar center (v20: rail-mounted)
+  const hearts = heartsElFor(side);
   const anchor = hearts || host;
   const r = anchor.getBoundingClientRect();
   const cx = (r.left + r.right) / 2 - host.getBoundingClientRect().left;
@@ -917,10 +923,11 @@ function findSideContainer(side) {
 
 
 function heartsHost(side) {
-  const hearts = document.getElementById(side === 'player' ? 'player-hearts' : 'ai-hearts');
-  // prefer the portrait wrapper if present, else the hearts node itself
-  const portrait = hearts?.closest('.portrait');
-  return portrait || hearts || findSideContainer(side);
+  // v20: hearts wrapper is gone; HP lives on the rail. Anchor damage VFX
+  // to the rail (where the HP bar now is) so cracks/shards still cluster
+  // around the HP indicator.
+  const rail = document.querySelector(side === 'player' ? '.wincon-rail.wc-player' : '.wincon-rail.wc-ai');
+  return rail || findSideContainer(side);
 }
 
 
@@ -937,7 +944,8 @@ function refreshHeartsShatter(side) {
 
 
 function heartsWrap(side) {
-  return document.getElementById(side === 'player' ? 'player-hearts' : 'ai-hearts');
+  // v20: redirect to the rail HP host (former hearts container).
+  return document.getElementById(side === 'player' ? 'player-wcr-hp' : 'ai-wcr-hp');
 }
 
 /** Mark the newest lost heart (rightmost empty) as 'shattered'. */
@@ -2053,13 +2061,9 @@ function heartSVG({ filled = true, size = 36 } = {}) {
  * Render hearts as "containers": show `maxHearts` outlines,
  * with the first `hp` hearts filled. Defaults to 12 max.
  */
-// v19: replaced 12-icon SVG row with a slim continuous HP bar.
-// 12 tiny 12×12px hearts on mobile portrait (~156px row) became a
-// "gray blur" — the wincon strip's numeric ♥ was carrying all the
-// at-a-glance load while the heart row was just visual noise. The
-// new bar is one icon + a thin 7px-tall track + a numeric value,
-// color-tiered green→amber→red as HP drops.
-function renderHearts(el, hp = 12, maxHearts = 12) {
+// v20: HP bar (was renderHearts in v19). Same body, renamed to clarify
+// it's now one of three sibling indicators on the wincon rail.
+function renderHpBar(el, hp = 12, maxHearts = 12) {
   if (!el) return;
   const max = Math.max(1, maxHearts | 0);
   const cur = Math.max(0, Math.min(hp | 0, max));
@@ -2078,6 +2082,62 @@ function renderHearts(el, hp = 12, maxHearts = 12) {
       `<div class="hp-bar-fill" style="width:${pct.toFixed(1)}%"></div>` +
     `</div>` +
     `<span class="hp-num">${cur}</span>`;
+}
+// Backward-compat alias: anything still calling renderHearts continues
+// to work (the v19 chip callers were removed, but external paths might
+// still reach it). Safe to delete in a later cleanup once verified.
+const renderHearts = renderHpBar;
+
+// v20: shared slim progress bar — same visual family as the HP bar so
+// HP / Confluence / Dominion all read as one unified row of indicators.
+// `kind` is a class hint (cf | dom) used by CSS for icon coloring; `near`
+// triggers the existing pulse highlight when one step from winning.
+function renderProgressBar(el, opts) {
+  if (!el) return;
+  const { icon = '◆', cur = 0, max = 1, label = '', kind = '', near = false } = opts || {};
+  const m = Math.max(1, max | 0);
+  const c = Math.max(0, Math.min(cur | 0, m));
+  const pct = (c / m) * 100;
+  el.classList.add('hp-bar-host', 'wcr-progress');
+  el.classList.toggle('near', !!near);
+  // strip stale kind classes, then add the current kind
+  el.classList.remove('wcr-cf','wcr-dom');
+  if (kind) el.classList.add(`wcr-${kind}`);
+  el.innerHTML =
+    `<span class="hp-icon" aria-hidden="true">${icon}</span>` +
+    `<div class="hp-bar-track" role="progressbar" ` +
+      `aria-valuemin="0" aria-valuemax="${m}" aria-valuenow="${c}" ` +
+      `aria-label="${label} ${c} of ${m}">` +
+      `<div class="hp-bar-fill" style="width:${pct.toFixed(1)}%"></div>` +
+    `</div>` +
+    `<span class="hp-num">${c}/${m}</span>`;
+}
+
+// v20: render one side's full WC rail (HP + Confluence + Dominion).
+// Replaces the v17 fixed top-right wincon strip and the v17 per-portrait
+// .win-tracks injection. Single canonical place per side, spatially
+// associated with that side's slot row.
+function renderWinconRail(side) {
+  const s = state;
+  const P = s?.players?.[side];
+  if (!P) return;
+  const hp  = P.vitality | 0;
+  const cf  = P.flowCardsAcquired | 0;
+  const dom = P.greyEssence | 0;
+  renderHpBar(document.getElementById(`${side}-wcr-hp`), hp, 12);
+  renderProgressBar(document.getElementById(`${side}-wcr-cf`), {
+    icon: '◇', cur: cf, max: 7, label: 'Confluence',
+    kind: 'cf', near: cf >= 6 && cf < 7,
+  });
+  renderProgressBar(document.getElementById(`${side}-wcr-dom`), {
+    icon: '▲', cur: dom, max: 10, label: 'Dominion',
+    kind: 'dom', near: dom >= 8 && dom < 10,
+  });
+  // Mirror near-state on the rail itself so CSS can pulse the whole bar.
+  const rail = document.querySelector(`.wincon-rail.wc-${side}`);
+  if (rail) {
+    rail.classList.toggle('near', (cf >= 6 && cf < 7) || (dom >= 8 && dom < 10) || (hp <= 1 && hp > 0));
+  }
 }
 
 
@@ -4122,36 +4182,10 @@ function showPendingWinBanner(side, condition) {
   setTimeout(() => banner.classList.remove("show"), 5000);
 }
 
-function renderWinTracks(side) {
-  const s    = serializePublic(state) || {};
-  const P    = s.players?.[side];
-  if (!P) return;
-  const cf   = P.flowCardsAcquired | 0;
-  const dom  = P.greyEssence       | 0;
-  const heartsEl = document.getElementById(side === 'player' ? 'player-hearts' : 'ai-hearts');
-  if (!heartsEl) return;
-  let wrap = heartsEl.parentElement?.querySelector('.win-tracks');
-  if (!wrap) {
-    wrap = document.createElement('div');
-    wrap.className = 'win-tracks';
-    heartsEl.insertAdjacentElement('afterend', wrap);
-  }
-  const cfPct  = Math.min(100, (cf  / 5)  * 100);
-  const domPct = Math.min(100, (dom / 10) * 100);
-  const cfNear  = cf  >= 4 ? ' near' : '';
-  const domNear = dom >= 8 ? ' near' : '';
-  wrap.innerHTML = `
-    <div class="win-track confluence${cfNear}" title="Confluence: ${cf}/5 Aetherflow cards">
-      <span class="wt-label">C</span>
-      <div class="wt-bar"><div class="wt-fill" style="width:${cfPct}%"></div></div>
-      <span>${cf}/5</span>
-    </div>
-    <div class="win-track dominion${domNear}" title="Dominion: ${dom}/10 Grey Essence">
-      <span class="wt-label">D</span>
-      <div class="wt-bar"><div class="wt-fill" style="width:${domPct}%"></div></div>
-      <span>${dom}/10</span>
-    </div>`;
-}
+// v20: renderWinTracks deleted. The chip-mounted Confluence/Dominion
+// mini-bars are now shown on the per-side wincon rail (renderWinconRail).
+// This codepath also had a stale "/5" Confluence threshold (real value is
+// 7 post-v18) — removing it fixes that bug as a side effect.
 
 // ---------- cinematic helpers ----------
 function ensureCinematicLayer() {
@@ -4716,8 +4750,8 @@ async function spotlightFromEvents(state){
       // Damage VFX (hearts + shatter + floater)
       if (e.t === 'damage') {
         if (e.side === 'player' || e.side === 'ai') {
-          const id = e.side === 'player' ? 'player-hearts' : 'ai-hearts';
-          const hearts = document.getElementById(id);
+          // v20: HP element moved to the rail HP host.
+          const hearts = heartsElFor(e.side);
           if (hearts) {
             hearts.classList.add('hit');
             hearts.addEventListener('animationend', () => hearts.classList.remove('hit'), { once: true });
@@ -5328,39 +5362,8 @@ function refreshSlotAffordance(){
   }
 }
 
-// 3. Win-condition tracker strip. Reads HP / Confluence / Dominion
-//    progress for both sides and updates the always-visible pill.
-//    Adds a `.near` class when a side is one step away from winning.
-function renderWinconStrip(){
-  const strip = document.getElementById('wincon-strip');
-  if (!strip) return;
-  const s = state;
-  if (!s?.players) return;
-
-  const sides = ['ai', 'player'];
-  sides.forEach(side => {
-    const p = s.players[side] || {};
-    const hp = p.vitality | 0;
-    const cf = (p.flowCardsAcquired | 0);
-    const dm = (p.greyEssence | 0);
-    const row = strip.querySelector(`.wc-row.wc-${side}`);
-    if (!row) return;
-    const hpEl = row.querySelector('.wc-hp .wc-val');
-    const cfEl = row.querySelector('.wc-cf .wc-val');
-    const dmEl = row.querySelector('.wc-dm .wc-val');
-    if (hpEl) hpEl.textContent = `${hp}`;
-    if (cfEl) {
-      cfEl.textContent = `${cf}/7`;
-      cfEl.classList.toggle('near', cf >= 6 && cf < 7);
-    }
-    if (dmEl) {
-      dmEl.textContent = `${dm}/10`;
-      dmEl.classList.toggle('near', dm >= 8 && dm < 10);
-    }
-    // HP "near" if at 1 — opponent is one shot from Ruin
-    if (hpEl) hpEl.classList.toggle('near', hp <= 1 && hp > 0);
-  });
-}
+// v20: renderWinconStrip removed. Per-side rendering now handled by
+// renderWinconRail(side) — see definition near renderHpBar.
 
 // 4a. Trance unlock — diff against last-known level per side and
 //     fire a centered toast + portrait flash on transitions.
@@ -5492,20 +5495,18 @@ async function render(){
   
   setAetherDisplay(playerAeEl, s.players?.player?.aether ?? 0, s.players?.player?.tempAether ?? 0);
   setAetherDisplay(aiAeEl,     s.players?.ai?.aether ?? 0,     s.players?.ai?.tempAether ?? 0);
-  // in render()
-  renderHearts($("player-hearts"), s.players?.player?.vitality ?? 12, 12);
-  renderHearts($("ai-hearts"),     s.players?.ai?.vitality     ?? 12, 12);
-  renderWinTracks('player');
-  renderWinTracks('ai');
+  // v20: HP / Confluence / Dominion all render on the per-side rail.
+  renderWinconRail('ai');
+  renderWinconRail('player');
 
   removeLegacyTranceText();
   renderTranceTrack('player');
   renderTranceTrack('ai');
   refreshPipAdvanceClasses();
 
-  // v17 game-flow clarity: affordances, win-strip, pivot moments
+  // v17 game-flow clarity: affordances, pivot moments. v20: wincon strip
+  // replaced by per-side rails (rendered above).
   refreshSlotAffordance();
-  renderWinconStrip();
   detectTranceUnlocks();
   detectHexApplied();
 
@@ -5976,15 +5977,18 @@ document.addEventListener("click", clearAllActionMenus);
 
 /* ---------- v17 wiring ---------- */
 
-// Wincon-strip click → toggle the small explainer popover.
+// v20: tap either wincon rail → toggle the "Three paths to victory"
+// explainer popover. Was previously bound to the fixed top-right strip.
 function wireWinconExplain(){
-  const strip   = document.getElementById('wincon-strip');
+  const rails = document.querySelectorAll('.wincon-rail');
   const explain = document.getElementById('wincon-explain');
-  if (!strip || !explain) return;
+  if (!rails.length || !explain) return;
   const close = explain.querySelector('.close');
-  strip.addEventListener('click', (ev) => {
-    ev.stopPropagation();
-    explain.classList.toggle('open');
+  rails.forEach(rail => {
+    rail.addEventListener('click', (ev) => {
+      ev.stopPropagation();
+      explain.classList.toggle('open');
+    });
   });
   close?.addEventListener('click', (ev) => {
     ev.stopPropagation();
@@ -5992,7 +5996,8 @@ function wireWinconExplain(){
   });
   // Dismiss when clicking elsewhere
   document.addEventListener('click', (ev) => {
-    if (!explain.contains(ev.target) && !strip.contains(ev.target)) {
+    const onRail = ev.target.closest?.('.wincon-rail');
+    if (!explain.contains(ev.target) && !onRail) {
       explain.classList.remove('open');
     }
   });

--- a/styles.css
+++ b/styles.css
@@ -36,11 +36,11 @@ html,body{height:100%}
   overflow:hidden;
 }
 
-/* Grid */
+/* Grid — v20: now 5 rows (AI / AI-rail / Flow / Player-rail / Player) */
 #board-grid.grid{
   display:grid !important;
-  grid-template-rows:auto auto auto !important;
-  row-gap:24px;
+  grid-template-rows: auto min-content auto min-content auto !important;
+  row-gap:14px;
   height:100%;
   padding:12px 16px calc(26vh + 12px);
   align-content:space-evenly;
@@ -425,11 +425,12 @@ body.mobile-landscape{
    space goes to the flow row. The slot tiles also slide out via
    transform so the transition reads as a coordinated "this player
    isn't playing right now". */
+/* v20: 5 grid rows = [ai, ai-rail, flow, player-rail, player] */
 body.mobile-landscape[data-active-side="player"] #board-grid.grid{
-  grid-template-rows: 0 minmax(0, 1fr) 56px !important;
+  grid-template-rows: 0 0 minmax(0, 1fr) min-content 56px !important;
 }
 body.mobile-landscape[data-active-side="ai"] #board-grid.grid{
-  grid-template-rows: 56px minmax(0, 1fr) 0 !important;
+  grid-template-rows: 56px min-content minmax(0, 1fr) 0 0 !important;
 }
 body.mobile-landscape #ai-slots.slot-row,
 body.mobile-landscape #player-slots.slot-row{
@@ -450,7 +451,7 @@ body.mobile-landscape[data-active-side="ai"] #player-slots.slot-row{
    first paint). Both rows visible at full height; v13 turn rules
    above will override. */
 body.mobile-landscape #board-grid.grid{
-  grid-template-rows: 56px minmax(0, 1fr) 56px !important;
+  grid-template-rows: 56px min-content minmax(0, 1fr) min-content 56px !important;
   row-gap: 6px !important;
   padding: var(--top-strip-h) 6px var(--hand-band-h) !important;
   height: 100vh;
@@ -771,10 +772,11 @@ body.mobile-landscape #ai-name{
    landscape they were adding visual noise without enough payoff.
    Players can see opponent hand size in the top-right counts
    already; trance/tracks are accessible via the menu. */
-body.mobile-landscape .portrait .trance-wrap,
-body.mobile-landscape .portrait .win-tracks{
+body.mobile-landscape .portrait .trance-wrap{
   display: none !important;
 }
+/* v20: .win-tracks element no longer rendered (removed in renderWinTracks
+   deletion). Selector retained for safety against any stale DOM. */
 body.mobile-landscape #ai-mini{
   display: none !important;
 }
@@ -819,19 +821,8 @@ body.mobile-landscape .portrait .trance-step.active::before{ display: none !impo
    collapsed so it doesn't leave a flex gap inside the chip. */
 body.mobile-landscape .portrait > .trance{ display: none !important; }
 
-/* Win tracks: thin bar pair, single-letter label, no x/y text */
-body.mobile-landscape .portrait .win-track{
-  font-size: .5rem;
-  gap: 2px;
-  line-height: 1;
-}
-body.mobile-landscape .portrait .win-track .wt-label{
-  font-size: .5rem;
-}
-body.mobile-landscape .portrait .win-track .wt-bar{
-  width: 20px !important; height: 3px !important;
-}
-body.mobile-landscape .portrait .win-track > span:last-child{ display: none; }
+/* v20: portrait .win-track rules removed — Confluence/Dominion now
+   render on the per-side .wincon-rail (see v20 block at file end). */
 
 /* Weaver backdrop — atmospheric character art behind the board, like
    StS's enemy art or MTG Arena's battlefield. Visible but not so bright
@@ -2127,8 +2118,9 @@ body.mobile-portrait #board-grid.grid{
   display: grid !important;
   /* Slot rows now use --slot-row-h so they grow with the card-shaped
      tile height (no more cramped 60px square). */
-  grid-template-rows: var(--slot-row-h) minmax(0, 1fr) var(--slot-row-h) !important;
-  row-gap: 8px !important;
+  /* v20: 5 rows — [ai, ai-rail, flow, player-rail, player] */
+  grid-template-rows: var(--slot-row-h) min-content minmax(0, 1fr) min-content var(--slot-row-h) !important;
+  row-gap: 6px !important;
   /* Top padding leaves room for AI chip; bottom padding leaves room
      for player chip + hand band. */
   padding: var(--top-strip-h) 8px calc(var(--hand-band-h) + 44px) !important;
@@ -2579,39 +2571,8 @@ body.mobile-portrait  .action-pop .rune-btn.has-desc .rb-desc{
   animation: slotAffordancePulse 1.6s ease-in-out infinite;
 }
 
-/* 3. Win-condition tracker strip — always visible, both sides.
-   v18: compacted (~110px wide × ~30px tall, was 140-160 × 38-44) so
-   it stops crowding the AI portrait/hearts. Tabular-nums keeps the
-   X/Y values aligned on both rows. */
-#wincon-strip {
-  position: fixed; top: 4px; right: 6px;
-  display: flex; flex-direction: column; gap: 1px;
-  background: rgba(20,16,12,.78);
-  border: 1px solid #4a3d2f; border-radius: 8px;
-  padding: 2px 6px;
-  z-index: 30; pointer-events: auto;
-  font-size: .58rem; font-weight: 600; letter-spacing: .02em;
-  color: #d6c8a4;
-  box-shadow: 0 3px 8px rgba(0,0,0,.45);
-  font-variant-numeric: tabular-nums;
-  cursor: pointer;
-}
-#wincon-strip .wc-row {
-  display: flex; gap: 6px; align-items: center; white-space: nowrap;
-}
-#wincon-strip .wc-row.wc-ai     { color: #d97a7a; }
-#wincon-strip .wc-row.wc-player { color: #c6a56a; }
-#wincon-strip .wc-row > span {
-  display: inline-flex; align-items: center; gap: 2px;
-}
-#wincon-strip .wc-val.near {
-  color: #ffd87a; text-shadow: 0 0 6px rgba(255,216,122,.55);
-}
-#wincon-strip .wc-icon { font-size: .9em; opacity: .85; line-height: 1; }
-body.mobile-portrait #wincon-strip,
-body.mobile-landscape #wincon-strip {
-  top: 24px; right: 4px; font-size: .54rem; padding: 2px 5px;
-}
+/* v20: #wincon-strip removed; per-side .wincon-rail elements now live
+   between the rows of #board-grid. See the v20 CSS block at file end. */
 /* Tap target: open a small explainer popover */
 #wincon-explain {
   position: fixed; top: 78px; right: 8px; max-width: 240px;
@@ -2748,15 +2709,15 @@ body.player-already-bought .row.flow .flow-card .card.market.buyable {
   /* Make sure the buyable pulse is suppressed when capped */
   animation: none !important;
 }
-body.player-already-bought #wincon-strip::after {
-  content: "✓ bought";
-  display: block;
-  margin-top: 2px;
-  font-size: .9em;
+/* v20: "✓ bought" affordance migrated from #wincon-strip onto the
+   player rail's Confluence host so it sits next to the bar that
+   actually advances when you buy. */
+body.player-already-bought .wincon-rail.wc-player .wcr-cf::after {
+  content: " ✓";
   color: #9ec38a;
-  text-align: right;
+  font-size: .9em;
+  margin-left: 4px;
   letter-spacing: .04em;
-  text-transform: uppercase;
   opacity: .85;
 }
 
@@ -2855,4 +2816,92 @@ body.mobile-landscape .hp-bar-host {
   align-items: center;
   flex-wrap: nowrap;
   min-width: 0;
+}
+
+
+/* ==========================================================
+   v20: WINCON RAILS BETWEEN ROWS
+   Two thin horizontal strips inside #board-grid, one per side,
+   each carrying that side's HP / Confluence / Dominion bars.
+   Replaces the fixed top-right #wincon-strip and the per-portrait
+   .win-tracks injection. Reuses the v19 .hp-bar-host markup so all
+   three indicators look like one unified family.
+   ========================================================== */
+
+.wincon-rail {
+  display: flex;
+  align-items: center;
+  gap: clamp(8px, 2vw, 18px);
+  padding: 4px clamp(8px, 2vw, 16px);
+  background: linear-gradient(180deg,
+              rgba(20,16,10,.55), rgba(20,16,10,.30));
+  border-top:    1px solid rgba(106,90,64,.35);
+  border-bottom: 1px solid rgba(106,90,64,.35);
+  font-variant-numeric: tabular-nums;
+  cursor: pointer;
+  user-select: none;
+}
+.wincon-rail.wc-ai     { color: #d97a7a; }
+.wincon-rail.wc-player { color: #c6a56a; }
+
+.wincon-rail .wcr-host {
+  flex: 1;
+  min-width: 0;
+}
+.wincon-rail .wcr-host.hp { flex: 1.4; }   /* HP gets a touch more room */
+
+/* Per-rail tinting — overrides the side-tints baked into .hp-bar-host
+   so all three bars on a single rail share that rail's colour. */
+.wincon-rail.wc-ai     .hp-bar-host .hp-icon,
+.wincon-rail.wc-ai     .hp-bar-host .hp-num    { color: #d97a7a !important; }
+.wincon-rail.wc-player .hp-bar-host .hp-icon,
+.wincon-rail.wc-player .hp-bar-host .hp-num    { color: #c6a56a !important; }
+
+/* CF / DM bar fills get distinct colour ramps so a glance can tell
+   which WC is which without reading the icon. */
+.wincon-rail .wcr-cf  .hp-bar-fill {
+  background: linear-gradient(90deg, #6b8fc4, #9ec3e7) !important;
+}
+.wincon-rail .wcr-dom .hp-bar-fill {
+  background: linear-gradient(90deg, #8b6fb0, #c2a3da) !important;
+}
+
+/* Near-win pulse — single CSS keyframe used by all three bars. */
+@keyframes wcrNearPulse {
+  0%, 100% { box-shadow: 0 0 0 0 rgba(255,216,122,0); }
+  50%      { box-shadow: 0 0 0 3px rgba(255,216,122,.45); }
+}
+.wincon-rail .wcr-progress.near .hp-bar-track {
+  animation: wcrNearPulse 1.4s ease-in-out infinite;
+  border-color: rgba(255,216,122,.55);
+}
+.wincon-rail.near {
+  /* rail-level tint when ANY of its three bars are at near-win */
+  background: linear-gradient(180deg,
+              rgba(60,40,16,.65), rgba(40,28,12,.40));
+}
+
+/* Mobile compact — make sure the rails don't bloat the playable area */
+body.mobile-portrait .wincon-rail,
+body.mobile-landscape .wincon-rail {
+  padding: 2px 6px;
+  gap: 6px;
+  font-size: .85em;
+}
+body.mobile-portrait .wincon-rail .hp-bar-host .hp-bar-track,
+body.mobile-landscape .wincon-rail .hp-bar-host .hp-bar-track {
+  height: 5px;
+}
+body.mobile-portrait .wincon-rail .hp-bar-host .hp-num,
+body.mobile-landscape .wincon-rail .hp-bar-host .hp-num {
+  font-size: .78em;
+}
+
+/* Damage VFX hit-flash on the rail's HP host (heartsElFor anchor) */
+.wincon-rail .wcr-host.hit {
+  animation: wcrHitFlash .32s ease-out;
+}
+@keyframes wcrHitFlash {
+  0%   { filter: brightness(1.8) drop-shadow(0 0 10px rgba(255,120,120,.7)); }
+  100% { filter: none; }
 }


### PR DESCRIPTION
User: *"Looks better. But maybe we can put each win condition between slots and aetherflow so it's clear?"*

The exploration found that v19 had three layout problems:
1. **Spatial association wrong** — both sides' WCs jammed into a fixed top-right corner; a glance couldn't tell you "what's MY current state".
2. **Triple-tracking redundancy** — HP shown on chip + on strip; Confluence/Dominion shown on chip `.win-tracks` + on strip.
3. **Stale Confluence threshold bug** — `renderWinTracks` displayed `cur/5`, but `CONFLUENCE_THRESHOLD = 7` post-v18.

User chose all three Recommended options: all 3 WCs on the new rails, remove HP from chip, remove the top-right strip, defer the broader 3-WC game-feel audit to a follow-up.

## Layout

Two new `<section class="wincon-rail wc-{ai|player}">` elements live inside `#board-grid` between the rows. AI rail sits directly above the Aether Flow market; Player rail directly below it. Each rail carries that side's HP / Confluence / Dominion bars.

`#board-grid` `grid-template-rows` updated to 5 tracks (rails as `min-content`) across the default, mobile-portrait, and mobile-landscape variants.

## JS

- `renderWinconRail(side)` renders all three bars via a shared `renderProgressBar` helper that produces the same `.hp-bar-host` markup as v19's HP bar — visual unification of the WC family.
- `renderHearts` renamed to `renderHpBar` (alias kept for safety).
- `renderWinTracks` deleted (subsumed; also fixes the `/5` → `/7` bug as a side effect).
- `renderWinconStrip` deleted.
- Render pipeline calls `renderWinconRail('ai')` + `('player')`.
- VFX anchor functions (`heartsElFor`, `heartsHost`, `heartsWrap`) redirect to the rail's HP host so damage shards/cracks/floaters still cluster around the HP indicator now that the chip-mounted hearts div is gone.
- `wireWinconExplain` rebound to listen on `.wincon-rail` elements.

## HTML
- Deleted `#wincon-strip` block.
- Deleted `.hearts` divs from both portraits.
- Inserted two `<section class="wincon-rail">` sections.

## CSS
- Deleted `#wincon-strip` rules and per-portrait `.win-track*` rules.
- New `.wincon-rail` / `.wcr-host` / `.wcr-progress` styling.
- Per-rail tinting: AI red, Player gold. CF blue ramp; DM purple ramp; HP keeps the green→amber→red tier ramp.
- `.near` pulse keyframe shared by all three bars.
- Mobile-compact overrides so rails don't bloat the playable area.
- "✓ bought" affordance migrated from `#wincon-strip::after` onto the player rail's Confluence host where it sits next to the bar that actually advances on a buy.

Cache-bust `mlv20-20260509`. Single squashable commit `ba009dd`.

## Out of scope (next conversation)

User explicitly deferred the **3-WC game-feel audit** (cards/trance/profession serving each WC) — and shared significant new design context on top: **the original vision** of two spell casters, **3 schools of magic** (black/white/grey, FF/LOTR style), **roguelite progression** (keep 1 card after each match, world-map left-to-right like a fighting game), and **boss fights every 3 matches with character unlocks**. That conversation continues after this PR ships.

---
_Generated by [Claude Code](https://claude.ai/code/session_01C1TYVtozydzcqvzpY15HMA)_