### PR TITLE
v21: schools (Black/White/Grey) + 8 cards + Ward/BonusBuy primitives

### DIFF
--- a/GameLogic.js
+++ b/GameLogic.js
@@ -390,11 +390,19 @@ function applyReactionEffect(state, reactionCard, trigger, context, reactingSide
 // Redesigned for HP 12, 3 Æ/turn economy.
 // Every card effect resolves with the parser.
 // =============================================
+// v21: every card now carries a `school` tag — black (aggression /
+// damage / hex), white (defense / heal / protection / Confluence
+// support), or grey (Aether economy / draw / advance / conversion).
+// The school field is metadata only (the parser ignores it); it
+// drives card-frame tinting and gives players a deckbuilding axis
+// that maps onto the three win conditions: Black→Ruin, White→
+// Confluence, Grey→Dominion. School-pair archetypes (Black+Grey,
+// White+Grey, Black+White) emerge naturally from card combinations.
 const BASE_DECK_LIST = [
   // Spells — play free, advance to resolve
   {
     name: "Pulse of the Grey",
-    type: "SPELL",
+    type: "SPELL", school: "grey",
     playCost: 0,
     stepCost: 0,
     pip: 1,
@@ -404,7 +412,7 @@ const BASE_DECK_LIST = [
   },
   {
     name: "Wisp of Insight",
-    type: "SPELL",
+    type: "SPELL", school: "grey",
     playCost: 0,
     stepCost: 0,
     pip: 1,
@@ -414,7 +422,7 @@ const BASE_DECK_LIST = [
   },
   {
     name: "Ashen Focus",
-    type: "SPELL",
+    type: "SPELL", school: "grey",
     playCost: 0,
     stepCost: 1,
     pip: 2,
@@ -424,7 +432,7 @@ const BASE_DECK_LIST = [
   },
   {
     name: "Wispform Surge",
-    type: "SPELL",
+    type: "SPELL", school: "grey",
     playCost: 0,
     stepCost: 1,
     pip: 1,
@@ -434,7 +442,7 @@ const BASE_DECK_LIST = [
   },
   {
     name: "Dormant Catalyst",
-    type: "SPELL",
+    type: "SPELL", school: "grey",
     playCost: 1,
     stepCost: 0,
     pip: 1,
@@ -444,7 +452,7 @@ const BASE_DECK_LIST = [
   },
   {
     name: "Greyfire Bloom",
-    type: "SPELL",
+    type: "SPELL", school: "black",
     playCost: 1,
     stepCost: 0,
     pip: 1,
@@ -454,7 +462,7 @@ const BASE_DECK_LIST = [
   },
   {
     name: "Ember Sigil",
-    type: "SPELL",
+    type: "SPELL", school: "black",
     playCost: 0,
     stepCost: 1,
     pip: 2,
@@ -466,7 +474,7 @@ const BASE_DECK_LIST = [
   // Instants — immediate effects
   {
     name: "Surge of Ash",
-    type: "INSTANT",
+    type: "INSTANT", school: "grey",
     playCost: 1,
     pip: 0,
     stepCost: 0,
@@ -476,7 +484,7 @@ const BASE_DECK_LIST = [
   },
   {
     name: "Veil of Dust",
-    type: "INSTANT",
+    type: "INSTANT", school: "grey",
     playCost: 1,
     pip: 0,
     stepCost: 0,
@@ -488,7 +496,7 @@ const BASE_DECK_LIST = [
   // Glyphs — persistent passives (one slot)
   {
     name: "Glyph of Remnant Light",
-    type: "GLYPH",
+    type: "GLYPH", school: "grey",
     playCost: 0,
     pip: 0,
     stepCost: 0,
@@ -498,7 +506,7 @@ const BASE_DECK_LIST = [
   },
   {
     name: "Glyph of Returning Echo",
-    type: "GLYPH",
+    type: "GLYPH", school: "grey",
     playCost: 0,
     pip: 0,
     stepCost: 0,
@@ -510,7 +518,7 @@ const BASE_DECK_LIST = [
   // Reaction — play on opponent's turn
   {
     name: "Hexing Wisp",
-    type: "REACTION",
+    type: "REACTION", school: "black",
     playCost: 0,
     pip: 0,
     stepCost: 0,
@@ -522,7 +530,7 @@ const BASE_DECK_LIST = [
   // Hex Spell — setup disruption
   {
     name: "Lingering Hex",
-    type: "SPELL",
+    type: "SPELL", school: "black",
     playCost: 1,
     stepCost: 0,
     pip: 1,
@@ -536,15 +544,17 @@ const BASE_DECK_LIST = [
 
 
 
-// ===== Aetherflow Deck (v6) — 18 cards =====
+// ===== Aetherflow Deck (v21) — 26 cards =====
 // All effects work with the live parser. Designed for HP-12 / 3-Æ-per-turn economy.
 // Combo packages: Hex engine · Advance engine · Store-Aether engine · Burst damage
+// v21: + White school (heal / ward / Confluence support) and Grey
+// Confluence enablers (free buys, buy synergies). 8 new cards.
 const AETHERFLOW_LIST = [
 
   // ── Burst / Scaling Damage ────────────────────────────────────
   {
     name: "Aether Burst",
-    type: "INSTANT",
+    type: "INSTANT", school: "black",
     pip: 0, playCost: 2, stepCost: 0, cost: 2,
     aetherValue: 0,
     text: "Deal damage equal to your Æ (max 6).",
@@ -553,7 +563,7 @@ const AETHERFLOW_LIST = [
   },
   {
     name: "Scorch the Many",
-    type: "INSTANT",
+    type: "INSTANT", school: "black",
     pip: 0, playCost: 2, stepCost: 0, cost: 2,
     aetherValue: 0,
     text: "Deal 4 damage.",
@@ -562,7 +572,7 @@ const AETHERFLOW_LIST = [
   },
   {
     name: "Cyclebreaker Lash",
-    type: "INSTANT",
+    type: "INSTANT", school: "black",
     pip: 0, playCost: 2, stepCost: 0, cost: 2,
     aetherValue: 0,
     text: "Deal 3 damage and Steal 2 Æ from opponent.",
@@ -573,7 +583,7 @@ const AETHERFLOW_LIST = [
   // ── Powerful Spells ───────────────────────────────────────────
   {
     name: "Reservoir Titan",
-    type: "SPELL",
+    type: "SPELL", school: "grey",
     pip: 2, playCost: 3, stepCost: 1, cost: 3,
     aetherValue: 2,
     text: "On Resolve → Store 4 Aether and Deal 2 damage.",
@@ -582,7 +592,7 @@ const AETHERFLOW_LIST = [
   },
   {
     name: "Echoflame Crusader",
-    type: "SPELL",
+    type: "SPELL", school: "black",
     pip: 2, playCost: 2, stepCost: 1, cost: 2,
     aetherValue: 1,
     text: "On Resolve → Deal 6 damage.",
@@ -591,7 +601,7 @@ const AETHERFLOW_LIST = [
   },
   {
     name: "Flowbinder Wisp",
-    type: "SPELL",
+    type: "SPELL", school: "grey",
     pip: 1, playCost: 1, stepCost: 0, cost: 1,
     aetherValue: 0,
     text: "On Resolve → Store 3 Aether and Draw 2 cards.",
@@ -600,7 +610,7 @@ const AETHERFLOW_LIST = [
   },
   {
     name: "Hex Implosion",
-    type: "SPELL",
+    type: "SPELL", school: "black",
     pip: 1, playCost: 2, stepCost: 1, cost: 2,
     aetherValue: 1,
     text: "On Resolve → Deal 2 damage. Reduce target’s Essence by 2.",
@@ -611,7 +621,7 @@ const AETHERFLOW_LIST = [
   // ── Aether Theft ─────────────────────────────────────────────
   {
     name: "Devouring Will",
-    type: "INSTANT",
+    type: "INSTANT", school: "black",
     pip: 0, playCost: 3, stepCost: 0, cost: 3,
     aetherValue: 0,
     text: "Steal 5 Æ from opponent.",
@@ -620,7 +630,7 @@ const AETHERFLOW_LIST = [
   },
   {
     name: "Echo Strike",
-    type: "INSTANT",
+    type: "INSTANT", school: "black",
     pip: 0, playCost: 2, stepCost: 0, cost: 2,
     aetherValue: 0,
     text: "Deal 2 damage. Advance another Spell.",
@@ -631,7 +641,7 @@ const AETHERFLOW_LIST = [
   // ── Hex Engine ────────────────────────────────────────────────
   {
     name: "Frozen Ember Sigil",
-    type: "INSTANT",
+    type: "INSTANT", school: "black",
     pip: 0, playCost: 1, stepCost: 0, cost: 1,
     aetherValue: 0,
     text: "Hex an enemy Spell Slot.",
@@ -640,7 +650,7 @@ const AETHERFLOW_LIST = [
   },
   {
     name: "Spite Wisp",
-    type: "REACTION",
+    type: "REACTION", school: "black",
     pip: 0, playCost: 1, stepCost: 0, cost: 1,
     aetherValue: 0,
     text: "When opponent plays a Spell → Hex that Spell Slot and Deal 1 damage.",
@@ -649,7 +659,7 @@ const AETHERFLOW_LIST = [
   },
   {
     name: "Creeping Malice",
-    type: "GLYPH",
+    type: "GLYPH", school: "black",
     pip: 0, playCost: 2, stepCost: 0, cost: 2,
     aetherValue: 0,
     text: "When a Spell resolves → Deal 1 damage.",
@@ -660,7 +670,7 @@ const AETHERFLOW_LIST = [
   // ── Advance Engine ────────────────────────────────────────────
   {
     name: "Rhythm of the Ashen Cycle",
-    type: "GLYPH",
+    type: "GLYPH", school: "grey",
     pip: 0, playCost: 2, stepCost: 0, cost: 2,
     aetherValue: 0,
     text: "When you Accelerate a Spell → Gain 1 Æ.",
@@ -669,7 +679,7 @@ const AETHERFLOW_LIST = [
   },
   {
     name: "Reversal Surge",
-    type: "INSTANT",
+    type: "INSTANT", school: "grey",
     pip: 0, playCost: 2, stepCost: 0, cost: 2,
     aetherValue: 0,
     text: "Advance another Spell. Gain 2 Æ and Draw 1 card.",
@@ -680,7 +690,7 @@ const AETHERFLOW_LIST = [
   // ── Utility ───────────────────────────────────────────────────
   {
     name: "Wisp of Purity",
-    type: "INSTANT",
+    type: "INSTANT", school: "white",
     pip: 0, playCost: 1, stepCost: 0, cost: 1,
     aetherValue: 0,
     text: "Remove Hex from all your Spell Slots. Draw 1 card.",
@@ -691,7 +701,7 @@ const AETHERFLOW_LIST = [
   // ── Win Condition Disruption ──────────────────────────────────
   {
     name: "Essence Siphon",
-    type: "INSTANT",
+    type: "INSTANT", school: "black",
     pip: 0, playCost: 2, stepCost: 0, cost: 2,
     aetherValue: 0,
     text: "Deal 2 damage. Reduce target’s Essence by 3.",
@@ -700,7 +710,7 @@ const AETHERFLOW_LIST = [
   },
   {
     name: "Current Seizure",
-    type: "INSTANT",
+    type: "INSTANT", school: "black",
     pip: 0, playCost: 2, stepCost: 0, cost: 2,
     aetherValue: 0,
     text: "Reduce target’s Confluence by 1. Draw 2 cards.",
@@ -709,11 +719,113 @@ const AETHERFLOW_LIST = [
   },
   {
     name: "Grasp of the Grey",
-    type: "INSTANT",
+    type: "INSTANT", school: "black",
     pip: 0, playCost: 3, stepCost: 0, cost: 3,
     aetherValue: 0,
     text: "Deal 4 damage. Reduce target’s Essence by 4.",
     role: "Anti-Dominion Finisher",
+    qty: 1
+  },
+
+  // ── v21: WHITE SCHOOL — defense / heal / Confluence ────────────
+  // Pure heal. Establishes the school's signature: trade tempo for
+  // staying-power. Reusable engine primitive (heal already exists
+  // in parseEffectsFromText / applyParsedEffects).
+  {
+    name: "Sanctifying Light",
+    type: "SPELL", school: "white",
+    pip: 2, playCost: 1, stepCost: 1, cost: 1,
+    aetherValue: 1,
+    text: "On Resolve → Heal 4.",
+    role: "Heal Spell",
+    qty: 1
+  },
+  // One-shot damage prevention. Ward = a token that absorbs the
+  // next instance of damage you would take, then expires.
+  {
+    name: "Wardweaver",
+    type: "SPELL", school: "white",
+    pip: 1, playCost: 0, stepCost: 0, cost: 0,
+    aetherValue: 1,
+    text: "On Resolve → Gain a Ward.",
+    role: "Ward Generator",
+    qty: 1
+  },
+  // Persistent shield glyph. Sets up a Ward each time a spell
+  // resolves; combo with damage-trigger glyphs creates an
+  // attrition wall.
+  {
+    name: "Aegis Glyph",
+    type: "GLYPH", school: "white",
+    pip: 0, playCost: 1, stepCost: 0, cost: 1,
+    aetherValue: 1,
+    text: "When a Spell resolves → Gain a Ward.",
+    role: "Ward Engine",
+    qty: 1
+  },
+  // Reactive heal. Trades the opportunity cost of holding a
+  // Reaction in hand for immediate stabilization. Anti-burst.
+  {
+    name: "Mercy of the Flow",
+    type: "REACTION", school: "white",
+    pip: 0, playCost: 1, stepCost: 0, cost: 1,
+    aetherValue: 0,
+    text: "When opponent deals damage → Heal 2 and Draw 1.",
+    role: "Reactive Heal",
+    qty: 1
+  },
+  // CONFLUENCE ENGINE (white). Bonus Buy bypasses the v18
+  // 1-per-turn cap once. The card itself counts as a buy when
+  // bought (from the Aetherflow market), and when cast lets you
+  // buy a SECOND time the same turn — so leaning into Confluence
+  // becomes a real strategic axis instead of a passive accumulator.
+  {
+    name: "Trade Winds",
+    type: "INSTANT", school: "white",
+    pip: 0, playCost: 2, stepCost: 0, cost: 2,
+    aetherValue: 0,
+    text: "Gain a Free Buy.",
+    role: "Confluence Engine",
+    qty: 1
+  },
+  // Persistent buy reward. Triggers via the existing buy glyph
+  // passive ("When you buy a card from Aether Flow → Draw 1").
+  // Means buying isn't just progress toward Confluence — it
+  // actively fuels your hand. White-Confluence anchor.
+  {
+    name: "Library Echo",
+    type: "GLYPH", school: "white",
+    pip: 0, playCost: 2, stepCost: 0, cost: 2,
+    aetherValue: 0,
+    text: "When you buy a card from Aether Flow → Draw 1.",
+    role: "Buy Synergy",
+    qty: 1
+  },
+
+  // ── v21: GREY × CONFLUENCE crossover cards ─────────────────────
+  // Grey-flavored Confluence engine. Frees the buy cap on Spell
+  // resolve — combos with the Grey advance engine (resolve faster
+  // → buy more often). Crossover archetype for Grey players who
+  // want a Confluence finisher path.
+  {
+    name: "Convergence Mark",
+    type: "GLYPH", school: "grey",
+    pip: 0, playCost: 2, stepCost: 0, cost: 2,
+    aetherValue: 1,
+    text: "When a Spell resolves → Gain a Free Buy.",
+    role: "Confluence Engine (Grey)",
+    qty: 1
+  },
+  // Grey aether-on-buy. Resolves → next buy gains 3 Æ. Lets
+  // expensive flow purchases self-fund. Pairs with Library Echo
+  // and Trade Winds to build a buy-engine deck.
+  {
+    name: "Aetherwoven Pact",
+    type: "SPELL", school: "grey",
+    pip: 2, playCost: 1, stepCost: 1, cost: 1,
+    aetherValue: 1,
+    text: "On Resolve → Next time you buy a card, Gain 3 Æ.",
+    role: "Buy Ramp",
     qty: 1
   }
 ];
@@ -837,7 +949,7 @@ export function initState(seed) {
     players: {
       player: {
         vitality: STARTING_VITALITY,
-        aether: AETHER_PER_TURN, channeled: 0, flowCardsAcquired: 0, greyEssence: 0, purchasesThisTurn: 0,
+        aether: AETHER_PER_TURN, channeled: 0, flowCardsAcquired: 0, greyEssence: 0, purchasesThisTurn: 0, wards: 0, bonusBuys: 0, pendingBuyAetherBonus: 0,
         deck: playerDeck, hand: handP, discard: [],
         slots: [
           { hasCard:false, card:null, hex:null },
@@ -849,7 +961,7 @@ export function initState(seed) {
       },
       ai: {
         vitality: STARTING_VITALITY,
-        aether: AETHER_PER_TURN, channeled: 0, flowCardsAcquired: 0, greyEssence: 0, purchasesThisTurn: 0,
+        aether: AETHER_PER_TURN, channeled: 0, flowCardsAcquired: 0, greyEssence: 0, purchasesThisTurn: 0, wards: 0, bonusBuys: 0, pendingBuyAetherBonus: 0,
         deck: aiDeck, hand: handAI, discard: [],
         slots: [
           { hasCard:false, card:null, hex:null },
@@ -1121,16 +1233,24 @@ export function discardForAether(state, playerId, cardId){
 export function dealDamage(state, targetSide, amount = 1, meta = {}) {
   const P = state.players?.[targetSide];
   if (!P) return state;
-  const n = Math.max(0, amount | 0);
+  let n = Math.max(0, amount | 0);
   if (n <= 0) return state;
 
 
  // Trigger reaction window before damage is applied (Aether Shield).
   state = triggerReactionWindow(state, "damage", { targetSide, amount: n, source: meta.source, cardId: meta.cardId });
 
+  // v21 — Ward consumption. One ward absorbs the entire incoming
+  // damage instance (matches Slay-the-Spire-style block where small
+  // hits and big hits are both eaten). If the consumer wants per-
+  // point absorption later we can switch to `n -= used; wards -= used`.
+  if ((P.wards | 0) > 0) {
+    P.wards = Math.max(0, (P.wards | 0) - 1);
+    pushEvt(state, { t: "ward_consumed", side: targetSide, absorbed: n, source: meta.source, cardId: meta.cardId });
+    return state;
+  }
 
 
-  
   const before = P.vitality | 0;
   P.vitality = Math.max(0, before - n);
   // After dealing damage, check for trance threshold updates
@@ -1262,8 +1382,14 @@ export function buyFromFlow(state, playerId, flowIndexRaw){
   // v18: enforce per-turn purchase cap. Confluence (buy 5/now 7 cards
   // from the Aether Flow) was the dominant strategy because there was
   // no structural cost to buying multiple times on a single rich turn.
+  // v21: a Bonus Buy token consumes one cap-bypass instead of blocking.
+  let useBonusBuy = false;
   if (((P.purchasesThisTurn | 0) >= MAX_BUYS_PER_TURN)) {
-    throw new Error("Already bought from Aether Flow this turn");
+    if ((P.bonusBuys | 0) > 0) {
+      useBonusBuy = true;
+    } else {
+      throw new Error("Already bought from Aether Flow this turn");
+    }
   }
 
  let price = FLOW_COSTS[flowIndex] || 0;
@@ -1307,8 +1433,23 @@ export function buyFromFlow(state, playerId, flowIndexRaw){
   P.flowCardsAcquired = (P.flowCardsAcquired | 0) + 1;
   pushEvt(state, { t: "confluence_gain", side: playerId, total: P.flowCardsAcquired });
 
-  // v18: tick the buy counter so the cap blocks further buys this turn
-  P.purchasesThisTurn = (P.purchasesThisTurn | 0) + 1;
+  // v18: tick the buy counter so the cap blocks further buys this turn.
+  // v21: a Bonus Buy bypass consumes the token instead of incrementing
+  // the counter, so the next buy still works against the cap normally.
+  if (useBonusBuy) {
+    P.bonusBuys = Math.max(0, (P.bonusBuys | 0) - 1);
+    pushEvt(state, { t: "bonus_buy_consumed", side: playerId });
+  } else {
+    P.purchasesThisTurn = (P.purchasesThisTurn | 0) + 1;
+  }
+
+  // v21: pending buy aether bonus (Aetherwoven Pact) — pay out once.
+  if ((P.pendingBuyAetherBonus | 0) > 0) {
+    const bonus = P.pendingBuyAetherBonus | 0;
+    P.aether = (P.aether | 0) + bonus;
+    P.pendingBuyAetherBonus = 0;
+    pushEvt(state, { t: "aether", side: playerId, amount: bonus, by: "pact" });
+  }
 
   // Normal buy event (kept as-is)
   pushEvt(state, {
@@ -1888,6 +2029,22 @@ function parseEffectsFromText(raw) {
   if (/remove hex from (?:all )?your spell slots/i.test(t))
     fx.push({ t: "cleanseHex" });
 
+  // v21 — White school primitives.
+  // Ward: damage-prevention token. Each ward absorbs one instance of
+  // damage. "Gain a Ward" / "Gain N Wards".
+  { const m = t.match(/\bgain\s+(?:a|an|(\d+))\s*wards?\b/i);
+    if (m) fx.push({ t: "ward", n: m[1] ? +m[1] : 1 }); }
+
+  // Bonus Buy: one-shot 1-per-turn-buy-cap bypass. Lets a White or
+  // Grey/Confluence deck make multiple purchases per turn.
+  { const m = t.match(/\bgain\s+(?:a|an|(\d+))\s*free\s*buys?\b/i);
+    if (m) fx.push({ t: "bonusBuy", n: m[1] ? +m[1] : 1 }); }
+
+  // Pending buy aether: "Next time you buy a card, Gain N Æ".
+  // Resolves once on the next purchase from Aetherflow (see buyFromFlow).
+  { const m = t.match(/next\s+time\s+you\s+buy\s+a?\s*card[, ]+gain\s+(\d+)\s*(?:æ|ae|aether)/i);
+    if (m) fx.push({ t: "pendingBuyAether", n: +m[1] }); }
+
   return fx;
 }
 
@@ -2207,6 +2364,36 @@ function applyParsedEffects(state, side, card, opts = {}) {
         }
         break;
       }
+
+      // v21 — White school: ward token. Increments the side's ward
+      // counter; dealDamage will consume one ward before applying
+      // damage. Stacks (N wards absorbs N hits).
+      case "ward":
+        if (e.n > 0) {
+          state.players[side].wards = (state.players[side].wards | 0) + e.n;
+          pushEvt(state, { t: "ward_gained", side, amount: e.n, by: card.id });
+        }
+        break;
+
+      // v21 — White/Grey: bonus-buy token. Lets the player buy from
+      // Aetherflow once even if they're already at the per-turn cap.
+      // Consumed by buyFromFlow.
+      case "bonusBuy":
+        if (e.n > 0) {
+          state.players[side].bonusBuys = (state.players[side].bonusBuys | 0) + e.n;
+          pushEvt(state, { t: "bonus_buy_gained", side, amount: e.n, by: card.id });
+        }
+        break;
+
+      // v21 — Grey: pending Aether bonus on next buy. Resolves on the
+      // next call to buyFromFlow.
+      case "pendingBuyAether":
+        if (e.n > 0) {
+          state.players[side].pendingBuyAetherBonus =
+            (state.players[side].pendingBuyAetherBonus | 0) + e.n;
+          pushEvt(state, { t: "pending_buy_aether", side, amount: e.n, by: card.id });
+        }
+        break;
 
       default: break;
     }

--- a/index.html
+++ b/index.html
@@ -5,7 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <title>The Grey — board</title>
   <link href="https://fonts.googleapis.com/css2?family=Cormorant+Garamond:wght@400;600&family=Crimson+Text:wght@600&display=swap" rel="stylesheet">
-  <link rel="stylesheet" href="./styles.css?v=mlv20-20260509" />
+  <link rel="stylesheet" href="./styles.css?v=mlv21-20260509" />
 </head>
 <body id="board" class="theme-dark parchment">
 
@@ -164,7 +164,7 @@
     </div>
   </div>
 
-  <script type="module" src="./index.js?v=mlv20-20260509"></script>
+  <script type="module" src="./index.js?v=mlv21-20260509"></script>
 </body>
 
 </html>

--- a/index.js
+++ b/index.js
@@ -2124,6 +2124,8 @@ function renderWinconRail(side) {
   const hp  = P.vitality | 0;
   const cf  = P.flowCardsAcquired | 0;
   const dom = P.greyEssence | 0;
+  const wards = P.wards | 0;
+  const free  = P.bonusBuys | 0;
   renderHpBar(document.getElementById(`${side}-wcr-hp`), hp, 12);
   renderProgressBar(document.getElementById(`${side}-wcr-cf`), {
     icon: '◇', cur: cf, max: 7, label: 'Confluence',
@@ -2133,11 +2135,35 @@ function renderWinconRail(side) {
     icon: '▲', cur: dom, max: 10, label: 'Dominion',
     kind: 'dom', near: dom >= 8 && dom < 10,
   });
+  // v21: surface Ward + Free Buy tokens as small inline badges on the
+  // rail. Wards sit next to HP (they absorb damage); Free Buys next to
+  // Confluence (they let you bypass the 1-buy-per-turn cap once each).
+  paintRailBadge(`${side}-wcr-hp`, 'ward', wards, '⛨');
+  paintRailBadge(`${side}-wcr-cf`, 'free-buy', free, '◇+');
+
   // Mirror near-state on the rail itself so CSS can pulse the whole bar.
   const rail = document.querySelector(`.wincon-rail.wc-${side}`);
   if (rail) {
     rail.classList.toggle('near', (cf >= 6 && cf < 7) || (dom >= 8 && dom < 10) || (hp <= 1 && hp > 0));
   }
+}
+
+// v21: append/update a rail token badge (Ward count, Free Buy count).
+// Idempotent: first call creates the badge, subsequent calls just update
+// the number and visibility. Hidden when count is 0.
+function paintRailBadge(hostId, kind, count, glyph) {
+  const host = document.getElementById(hostId);
+  if (!host) return;
+  let badge = host.querySelector(`.wcr-badge.b-${kind}`);
+  if (!badge) {
+    badge = document.createElement('span');
+    badge.className = `wcr-badge b-${kind}`;
+    badge.innerHTML = `<span class="b-ico" aria-hidden="true">${glyph}</span><span class="b-n">0</span>`;
+    host.appendChild(badge);
+  }
+  badge.classList.toggle('hidden', !count);
+  const n = badge.querySelector('.b-n');
+  if (n) n.textContent = String(count);
 }
 
 
@@ -2260,7 +2286,13 @@ const pipDots = `<div class="pip-track">${
   const rulesRaw = withAetherText(cleanRulesText(c.text || ""));
   const rulesForDisplay = resolveTerminologyForDisplay(c, rulesRaw);
 
+  // v21: school marker. Black / White / Grey colour the left edge of
+  // the card so a player can read deck composition at a glance. Default
+  // is grey (the neutral, untaggged look) so legacy cards still render.
+  const school = (c.school || 'grey').toLowerCase();
+
   return `
+    <div class="school-stripe school-${school}" aria-hidden="true"></div>
     <div class="title">${c.name}</div>
     <div class="type" data-k="${c.type||""}">${c.type||""}</div>
     ${playCost !== null ? `<div class="play-cost-badge"><span class="v">${playCost}</span></div>` : ``}

--- a/styles.css
+++ b/styles.css
@@ -2905,3 +2905,94 @@ body.mobile-landscape .wincon-rail .hp-bar-host .hp-num {
   0%   { filter: brightness(1.8) drop-shadow(0 0 10px rgba(255,120,120,.7)); }
   100% { filter: none; }
 }
+
+
+/* ==========================================================
+   v21: SCHOOLS — visual identity for Black / White / Grey
+   - .school-stripe inside every card via cardShellHTML
+   - :has() lets us tint the whole .card frame from the stripe
+   - Rail badges for Ward + Free Buy tokens
+   ========================================================== */
+
+/* Stripe: a thin bar on the LEFT EDGE of every card, full height.
+   Lives inside .card content; CSS pins it absolutely. */
+.card .school-stripe {
+  position: absolute;
+  left: 0; top: 0; bottom: 0;
+  width: 4px;
+  border-radius: 8px 0 0 8px;
+  pointer-events: none;
+  z-index: 2;
+}
+.card .school-stripe.school-black {
+  background: linear-gradient(180deg, #1a0c0c 0%, #5a1a1a 50%, #1a0c0c 100%);
+  box-shadow: inset 1px 0 0 rgba(217,122,122,.35);
+}
+.card .school-stripe.school-white {
+  background: linear-gradient(180deg, #d8c89a 0%, #f3e4b3 50%, #b8a572 100%);
+  box-shadow: inset 1px 0 0 rgba(255,240,200,.55);
+}
+.card .school-stripe.school-grey {
+  background: linear-gradient(180deg, #404048 0%, #707080 50%, #303038 100%);
+  box-shadow: inset 1px 0 0 rgba(180,185,200,.25);
+}
+
+/* Whole-frame subtle tint via :has() — modern browsers support it.
+   We keep the tint small so card text stays readable. */
+.card:has(.school-stripe.school-black) {
+  border-color: rgba(140,40,40,.45);
+  background-image: linear-gradient(180deg, rgba(40,8,8,.18) 0%, transparent 40%);
+}
+.card:has(.school-stripe.school-white) {
+  border-color: rgba(200,180,120,.55);
+  background-image: linear-gradient(180deg, rgba(220,200,140,.10) 0%, transparent 40%);
+}
+.card:has(.school-stripe.school-grey) {
+  border-color: rgba(120,125,140,.45);
+  /* Grey is the neutral default — no tint, lets existing palette dominate. */
+}
+
+/* Rail token badges (Ward, Free Buy). Inline, compact. */
+.wcr-host { position: relative; }
+.wcr-badge {
+  display: inline-flex;
+  align-items: center;
+  gap: 2px;
+  margin-left: 6px;
+  padding: 1px 5px;
+  border-radius: 8px;
+  background: rgba(20,16,10,.7);
+  border: 1px solid rgba(180,160,100,.5);
+  font-size: .72em;
+  font-weight: 700;
+  color: #e7dcc3;
+  vertical-align: middle;
+  line-height: 1.1;
+  transition: opacity .2s ease, transform .2s ease;
+}
+.wcr-badge.hidden {
+  opacity: 0;
+  transform: scale(.8);
+  pointer-events: none;
+  position: absolute;
+}
+.wcr-badge.b-ward {
+  border-color: rgba(160,200,255,.7);
+  background: rgba(20,30,50,.8);
+  color: #b6d4ff;
+}
+.wcr-badge.b-free-buy {
+  border-color: rgba(160,255,200,.7);
+  background: rgba(20,40,30,.8);
+  color: #aef0c8;
+}
+.wcr-badge .b-ico { font-size: .9em; line-height: 1; }
+.wcr-badge .b-n   { font-variant-numeric: tabular-nums; }
+
+/* Mobile compact — keep the badges from crowding small chips */
+body.mobile-portrait  .wcr-badge,
+body.mobile-landscape .wcr-badge {
+  margin-left: 3px;
+  padding: 0 3px;
+  font-size: .65em;
+}


### PR DESCRIPTION
User shared the original game vision: 2 casters dueling across **3 schools of magic** (Black / White / Grey), roguelite progression with keep-1-card after each match, world-map left-to-right runs, boss every 3 matches with character unlocks. The user picked phase 1 (card-pool audit + targeted additions) as the starting point and approved all-Recommended scope.

## Audit findings

Pre-v21 the 31-card pool tagged out as **Black 16 / Grey 14 / White 1**. Worse, **Confluence had no card-level engine** — buy 7 from Aetherflow over 7+ turns, no card interacts with the buy mechanic. So "3 win conditions" played as one strategy (race HP) plus two passive accumulators.

## Schema

Every card in `BASE_DECK_LIST` and `AETHERFLOW_LIST` now carries a `school: 'black' | 'white' | 'grey'` field. Metadata only — the parser ignores it. School maps to a primary WC: **Black→Ruin, White→Confluence, Grey→Dominion**. Players choose a strategy by leaning a school in their drafts.

## New engine primitives

| Primitive | Triggers | State | Behavior |
|---|---|---|---|
| `ward` | "Gain a Ward" / "Gain N Wards" | `players[side].wards` | One ward absorbs the entire next damage instance |
| `bonusBuy` | "Gain a Free Buy" / "Gain N Free Buys" | `players[side].bonusBuys` | Bypasses v18 1-per-turn cap once each |
| `pendingBuyAether` | "Next time you buy a card, Gain N Æ" | `players[side].pendingBuyAetherBonus` | Pays out once on next `buyFromFlow` |

`heal` and the `buy → draw` glyph passive trigger were already wired.

## 8 new cards (Aetherflow market)

**White school (defense / heal / Confluence support):**
- **Sanctifying Light** SPELL — Heal 4 on resolve
- **Wardweaver** SPELL — Gain a Ward on resolve
- **Aegis Glyph** GLYPH — Spell resolves → Gain a Ward
- **Mercy of the Flow** REACTION — Opponent damage → Heal 2 + Draw 1
- **Trade Winds** INSTANT — Gain a Free Buy
- **Library Echo** GLYPH — Buy from Aether Flow → Draw 1

**Grey × Confluence crossover:**
- **Convergence Mark** GLYPH — Spell resolves → Gain a Free Buy
- **Aetherwoven Pact** SPELL — Resolve → next buy gains 3 Æ

**Final distribution: Black 16 / Grey 16 / White 7.** Confluence finally has a real card-level engine.

## UI

- **School stripes** — `cardShellHTML` emits a left-edge `.school-stripe.school-{x}` div inside every card. CSS uses `:has()` to tint the entire frame border and apply a subtle surface gradient based on stripe class. Zero changes needed to the dozen `.card` creation sites scattered through `index.js`.
- **Rail badges** — `paintRailBadge()` adds inline tokens on the HP host (Ward ⛨, cool-blue) and CF host (Free Buy ◇+, cool-green). Hide at zero, fade in when gained.

Stripe palette: Black = obsidian→red gradient, White = cream→gold gradient, Grey = neutral silver.

Cache-bust `mlv21-20260509`. Single squashable commit `a71604d`.

## Out of scope (deferred)

This is the first PR in the **3-phase make-it-fun roadmap** the user approved:
1. ✓ Card-pool audit + school-anchored additions ← THIS PR
2. Trance as character identity (each weaver's trance unlocks something only one school does)
3. Roguelite run loop (map screen, keep-1-card, boss every 3, character unlocks)

Phases 2 + 3 are separate PRs once we play-test how matches feel with schools active.

---
_Generated by [Claude Code](https://claude.ai/code/session_01C1TYVtozydzcqvzpY15HMA)_