### PR TITLE
v22: trance-as-identity (Morr Black rebuild) + HUD relocation

### DIFF
--- a/GameLogic.js
+++ b/GameLogic.js
@@ -949,7 +949,7 @@ export function initState(seed) {
     players: {
       player: {
         vitality: STARTING_VITALITY,
-        aether: AETHER_PER_TURN, channeled: 0, flowCardsAcquired: 0, greyEssence: 0, purchasesThisTurn: 0, wards: 0, bonusBuys: 0, pendingBuyAetherBonus: 0,
+        aether: AETHER_PER_TURN, channeled: 0, flowCardsAcquired: 0, greyEssence: 0, purchasesThisTurn: 0, wards: 0, bonusBuys: 0, pendingBuyAetherBonus: 0, tranceI_used: false,
         deck: playerDeck, hand: handP, discard: [],
         slots: [
           { hasCard:false, card:null, hex:null },
@@ -957,11 +957,11 @@ export function initState(seed) {
           { hasCard:false, card:null, hex:null },
           { isGlyph:true, hasCard:false, card:null, hex:null  },
         ],
-        weaver: { id:"aria", name:"Aria, Runesurge Adept", stage:0, portrait:"./weaver_aria_Portrait.jpg" },
+        weaver: { id:"aria", name:"Aria, Runesurge Adept", school:"grey", stage:0, portrait:"./weaver_aria_Portrait.jpg" },
       },
       ai: {
         vitality: STARTING_VITALITY,
-        aether: AETHER_PER_TURN, channeled: 0, flowCardsAcquired: 0, greyEssence: 0, purchasesThisTurn: 0, wards: 0, bonusBuys: 0, pendingBuyAetherBonus: 0,
+        aether: AETHER_PER_TURN, channeled: 0, flowCardsAcquired: 0, greyEssence: 0, purchasesThisTurn: 0, wards: 0, bonusBuys: 0, pendingBuyAetherBonus: 0, tranceI_used: false,
         deck: aiDeck, hand: handAI, discard: [],
         slots: [
           { hasCard:false, card:null, hex:null },
@@ -969,7 +969,7 @@ export function initState(seed) {
           { hasCard:false, card:null, hex:null },
           { isGlyph:true, hasCard:false, card:null, hex:null  },
         ],
-        weaver: { id:"morr", name:"Morr, Gravecurrent Binder", stage:0, portrait:"./weaver_morr_Portrait.jpg" },
+        weaver: { id:"morr", name:"Morr, Gravecurrent Binder", school:"black", stage:0, portrait:"./weaver_morr_Portrait.jpg" },
       }
     }
   };
@@ -1134,9 +1134,12 @@ export function startTurn(state) {
 
   // v18: reset the per-turn flow purchase counter for the active side
   // so the buy cap (MAX_BUYS_PER_TURN) refreshes each turn.
+  // v22: also reset the once/turn trance trigger flag so abilities like
+  // Morr's Gravecurrent Tithe can fire again this turn.
   const _activeForBuys = state.activePlayer;
   if (state.players?.[_activeForBuys]) {
     state.players[_activeForBuys].purchasesThisTurn = 0;
+    state.players[_activeForBuys].tranceI_used = false;
   }
 
   // Confirm a pending win if it's now the winner's turn to start
@@ -1253,6 +1256,24 @@ export function dealDamage(state, targetSide, amount = 1, meta = {}) {
 
   const before = P.vitality | 0;
   P.vitality = Math.max(0, before - n);
+
+  // v22 — Morr Stage I (Gravecurrent Tithe): when Morr takes damage,
+  // bleed 1 HP back to the attacker AND gain 1 Æ. Once per turn. This
+  // is Morr's Black-school identity: aggression punishes aggression,
+  // and his tithe converts pain into power.
+  const wMorr = P.weaver;
+  const isMorr = wMorr?.id === "morr" && (wMorr.stage | 0) >= 1;
+  const notSelfDamage = meta.source !== "trance-morr-tithe" && meta.source !== "self";
+  if (isMorr && notSelfDamage && !P.tranceI_used) {
+    P.tranceI_used = true;
+    P.aether = (P.aether | 0) + 1;
+    pushEvt(state, { t: "aether", side: targetSide, amount: 1, by: "trance-morr-tithe" });
+    const attacker = otherSide(targetSide);
+    // Recursive call is safe: the attacker isn't Morr (or if they are,
+    // their own tithe already fired or is gated by tranceI_used). Source
+    // tag prevents infinite ping-pong.
+    state = dealDamage(state, attacker, 1, { source: "trance-morr-tithe" });
+  }
   // After dealing damage, check for trance threshold updates
   state = checkTranceThresholds(state, targetSide);
 
@@ -1395,9 +1416,7 @@ export function buyFromFlow(state, playerId, flowIndexRaw){
  let price = FLOW_COSTS[flowIndex] || 0;
   // Morr Stage II: flow costs 1 less (minimum 0)
   const wF = state.players[playerId]?.weaver;
-  if (wF?.id === "morr" && (wF.stage | 0) >= 2) {
-    price = Math.max(0, price - 1);
-  }
+  // v22: removed Morr Stage II buy-discount (was: -1 to flow cost).
   const haveTemp = (P.tempAether | 0);
   const haveReg  = (P.aether | 0);
   if (haveTemp + haveReg < price) throw new Error("Not enough Æ");
@@ -1421,11 +1440,8 @@ export function buyFromFlow(state, playerId, flowIndexRaw){
   // Process Kareth spend triggers
   state = processAetherSpend(state, playerId, price);
 
-  // Morr Stage II: after buying, gain 1 Æ
-  if (wF?.id === "morr" && (wF.stage | 0) >= 2) {
-    P.aether = (P.aether | 0) + 1;
-    pushEvt(state, { t:"aether", side: playerId, amount: 1, by: "trance-morr" });
-  }
+  // v22: removed Morr Stage II Flow-buy bonus (was: +1 Æ after buy).
+  // Stage II is now the Last Rites resolve trigger.
 
 
   
@@ -1744,10 +1760,15 @@ export function advanceSpell(
 
 
     // Morr Stage I: gain 1 Æ when a card leaves a slot
-    const w3 = P.weaver;
-    if (w3?.id === "morr" && (w3.stage | 0) >= 1) {
-      P.aether = (P.aether | 0) + 1;
-      pushEvt(state, { t: "aether", side: playerId, amount: 1, by: "trance-morr" });
+    // v22 — Morr Stage II (Last Rites): when one of Morr's Spells
+    // resolves, deal +1 damage and lose 1 HP. Black-school sacrifice:
+    // every casting costs blood and lands harder.
+    const wM = P.weaver;
+    if (wM?.id === "morr" && (wM.stage | 0) >= 2) {
+      const opp = otherSide(playerId);
+      state = dealDamage(state, opp, 1, { source: "trance-morr-rites", cardId: c?.id });
+      state = dealDamage(state, playerId, 1, { source: "self" });
+      pushEvt(state, { t: "trance_fired", side: playerId, by: "trance-morr-rites" });
     }
 
     
@@ -1836,11 +1857,8 @@ export function resolveGlyphFromSlot(state, playerId){
 
   
   // Morr Stage I: gain 1 Æ when a glyph leaves a slot
-  const w = P.weaver;
-  if (w?.id === "morr" && (w.stage | 0) >= 1) {
-    P.aether = (P.aether | 0) + 1;
-    pushEvt(state, { t:"aether", side: playerId, amount: 1, by: "trance-morr" });
-  }
+  // v22: old Morr Stage I "glyph leaves slot → +1 Æ" removed.
+  // Stage I is now the damage-back tithe inside dealDamage.
   
   return state;
 }

--- a/index.html
+++ b/index.html
@@ -5,7 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <title>The Grey — board</title>
   <link href="https://fonts.googleapis.com/css2?family=Cormorant+Garamond:wght@400;600&family=Crimson+Text:wght@600&display=swap" rel="stylesheet">
-  <link rel="stylesheet" href="./styles.css?v=mlv21-20260509" />
+  <link rel="stylesheet" href="./styles.css?v=mlv22-20260509" />
 </head>
 <body id="board" class="theme-dark parchment">
 
@@ -164,7 +164,7 @@
     </div>
   </div>
 
-  <script type="module" src="./index.js?v=mlv21-20260509"></script>
+  <script type="module" src="./index.js?v=mlv22-20260509"></script>
 </body>
 
 </html>

--- a/index.js
+++ b/index.js
@@ -3841,8 +3841,10 @@ const TRANCE_DATA = {
   Morr: {
     thresholds: [4, 1],
     stages: [
-      { name: "Gravecurrent Tithe", effect: "When a card leaves a Slot: gain +1 Æ (once/turn)." },
-      { name: "Flow Bargain",       effect: "First Flow buy each turn costs 1 less Æ and Channel 1." }
+      // v22 — Black-school identity: vampire/sacrifice. Stage I bleeds
+      // attackers; Stage II turns every casting into a blood-rite.
+      { name: "Gravecurrent Tithe", effect: "When you take damage: opponent loses 1 HP and you gain 1 Æ (once/turn)." },
+      { name: "Last Rites",         effect: "When one of your Spells resolves: deal 1 extra damage and lose 1 HP." }
     ]
   },
   Veyra: {
@@ -3897,15 +3899,16 @@ const WEAVER_TRANCE = {
   },
 
   Morr: {
+    // v22 — Black-school identity rewrite (matches Morr block above).
     tiers: [
       {
-        name: "Gravecurrent",
-        desc: "When a card leaves a Slot: gain +1 Æ (once/turn).",
+        name: "Gravecurrent Tithe",
+        desc: "When you take damage: opponent loses 1 HP and you gain 1 Æ (once/turn).",
         threshold: 4
       },
       {
-        name: "Tithe of the Flow",
-        desc: "Your first Aether Flow purchase each turn costs 1 less Æ and Channel 1.",
+        name: "Last Rites",
+        desc: "When one of your Spells resolves: deal 1 extra damage and lose 1 HP.",
         threshold: 1
       }
     ]
@@ -5519,6 +5522,16 @@ async function render(){
 
       playerName     && (playerName.textContent = s.players?.player?.weaver?.name || "Player");
       aiName         && (aiName.textContent     = s.players?.ai?.weaver?.name || "Opponent");
+
+      // v22: stamp the school onto each portrait so CSS can paint a
+      // school-tinted ring + label badge under the portrait, making
+      // each weaver's deckbuilding identity visible at a glance.
+      const psFig = playerPortrait?.closest('.portrait');
+      const asFig = aiPortrait?.closest('.portrait');
+      const pSch  = (s.players?.player?.weaver?.school || 'grey').toLowerCase();
+      const aSch  = (s.players?.ai?.weaver?.school     || 'grey').toLowerCase();
+      if (psFig) psFig.dataset.school = pSch;
+      if (asFig) asFig.dataset.school = aSch;
 
 
 

--- a/styles.css
+++ b/styles.css
@@ -2996,3 +2996,79 @@ body.mobile-landscape .wcr-badge {
   padding: 0 3px;
   font-size: .65em;
 }
+
+
+/* ==========================================================
+   v22: TRANCE-AS-IDENTITY + HUD relocation
+   - Bottom-right End Turn / Deck / Discard cluster moved to the
+     empty top-right corner (mobile only). Top-right has been
+     unused since v20 removed the wincon strip.
+   - Portrait chip gets a school-tinted ring matching the weaver's
+     school (Aria=grey, Morr=black) so deckbuilding identity is
+     visible from the start.
+   ========================================================== */
+
+/* HUD: top-right horizontal cluster on mobile portrait. Override the
+   v17 vertical-stack rules. Desktop still uses the original right-
+   side vertical layout. */
+body.mobile-portrait .hud{
+  position: fixed !important;
+  right: 6px !important;
+  top: 6px !important;
+  bottom: auto !important;
+  left: auto !important;
+  flex-direction: row !important;
+  gap: 6px !important;
+  z-index: 50;
+}
+body.mobile-portrait .hud-btn{
+  width: 36px !important;
+  height: 36px !important;
+  border-radius: 8px !important;
+  font-size: 13px !important;
+}
+/* End-turn: same row, slightly larger as the most-tapped action. */
+body.mobile-portrait #btn-endturn-hud{
+  position: static !important;
+  width: 48px !important;
+  height: 36px !important;
+  border-radius: 10px !important;
+  font-size: 18px !important;
+  background: #c6a56a;
+  color: #0d0a07;
+  border: 1px solid #4a3d2f;
+  box-shadow: 0 4px 10px rgba(0,0,0,.45);
+  /* sits inside the .hud flex row so order is controlled here */
+  order: 0;
+}
+body.mobile-portrait #btn-discard-hud { order: 1; }
+body.mobile-portrait #btn-deck-hud    { order: 2; }
+/* Mobile landscape: keep existing left-side stack (no override). */
+
+/* Portrait chip school identity ring. Lives on .portrait via a CSS
+   variable set per-side from the weaver.school (we just colour both
+   sides until the AI weaver is also school-tagged at runtime). */
+.portrait[data-school="black"] { --school-tint: rgba(140,40,40,.65); }
+.portrait[data-school="white"] { --school-tint: rgba(220,200,140,.85); }
+.portrait[data-school="grey"]  { --school-tint: rgba(140,150,170,.55); }
+.portrait[data-school] img {
+  outline: 2px solid var(--school-tint, transparent);
+  outline-offset: 1px;
+  transition: outline-color .25s ease;
+}
+.portrait[data-school]::after {
+  content: attr(data-school);
+  position: absolute;
+  bottom: -2px; left: 50%;
+  transform: translateX(-50%);
+  text-transform: uppercase;
+  letter-spacing: .12em;
+  font-size: .56em;
+  font-weight: 700;
+  color: var(--school-tint, #999);
+  background: rgba(20,16,10,.85);
+  border: 1px solid var(--school-tint, #555);
+  border-radius: 6px;
+  padding: 1px 5px;
+  pointer-events: none;
+}


### PR DESCRIPTION
User: *"Better but still needs work. Let's work on the trance identity next. Also not sure if need all 3 buttons on bottom right maybe that can get rethought, it's in the way."*

**Phase 2 of the make-it-fun roadmap** (after v21 schools): each weaver's trance now mechanically reinforces a school identity. Plus the bottom-right HUD relocates to the empty top-right corner.

## Audit findings (Phase 2)

- **Aria** stages were already Grey-coded mechanically (advance triggers, advance discount). Identity matched the school. **Locked in.**
- **Morr** stages were *neutral* despite his Gravecurrent/Tithe naming — "+1 Æ when card leaves slot" + "first Flow buy -1 cost". Generic Aether ramp / merchant. **Rebuilt for Black school.**

User picked all-Recommended: Full Black rebuild for Morr, top-right HUD relocation.

## Morr Trance — Black-school rebuild

| Stage | Old (neutral) | New (Black: vampire/sacrifice) |
|---|---|---|
| I — Gravecurrent Tithe | Card leaves slot → +1 Æ | **When you take damage → opponent loses 1 HP and you gain 1 Æ (once/turn)** |
| II — Last Rites (was "Flow Bargain") | First buy -1 Æ + Channel 1 | **When one of your Spells resolves → deal 1 extra damage and lose 1 HP** |

**Implementation notes:**
- Stage I runs *inside* `dealDamage()` *before* the v21 ward check — wards can't suppress the punisher trigger.
- Source-tag (`trance-morr-tithe`) on the recursive damage call prevents infinite ping-pong.
- Stage II hooks into the spell-resolve flow where the old "+1 Æ on slot leave" lived.
- Per-turn trigger flag (`tranceI_used`) resets in `startTurn` alongside the v18 buy-cap counter.
- All 4 obsolete Morr hooks removed (2× Stage I in resolve flows; 2× Stage II in buyFromFlow).

## HUD relocation (mobile portrait only)

Bottom-right vertical stack of `[End Turn / Discard / Deck]` → top-right horizontal cluster. Top-right has been empty since v20 removed the wincon strip. End Turn stays the largest (most-tapped). Frees up the play area where the buttons had been overlapping the rightmost flow card and the player's glyph slot. **Desktop layout unchanged.**

## Chip school stripe

`render()` stamps `data-school={black|white|grey}` onto each `.portrait` `<figure>` from `weaver.school`. CSS adds a school-tinted outline ring on the portrait img + a tiny school-name badge underneath (`GREY` / `BLACK` / `WHITE`). Aria reads as GREY, Morr reads as BLACK at a glance — before any cards are seen.

## Schema additions

- `players[side].weaver.school` (`'grey'` for Aria, `'black'` for Morr).
- `players[side].tranceI_used` (boolean, reset on turn start).

## Files

| File | Change |
|---|---|
| `GameLogic.js` | Weaver `school` field; new `tranceI_used` state; Morr Stage I block in `dealDamage`; Morr Stage II block in spell resolve; obsolete Morr hooks removed; `startTurn` resets the flag |
| `index.js` | Both Morr trance description blocks rewritten; `data-school` stamped onto portraits in `render()` |
| `styles.css` | Mobile-portrait `.hud` overrides → top-right horizontal cluster; portrait `[data-school]` ring + label badge |
| `index.html` | Cache-bust `mlv22-20260509` |

Single squashable commit `27bc092`.

## Roadmap progress

1. ✓ Schools as deckbuilding axis (v21)
2. ✓ Trance as character identity (this PR)
3. Roguelite run loop (map screen, keep-1-card, boss every 3, character unlocks) — **next**

The 3 unimplemented weavers (Enoch, Veyra, Kareth) will get school tags + identity passes when they're wired into character selection in phase 3.

---
_Generated by [Claude Code](https://claude.ai/code/session_01C1TYVtozydzcqvzpY15HMA)_