### PR TITLE
v23: fix HUD relocation regression + boost school stripe visibility

### DIFF
--- a/index.html
+++ b/index.html
@@ -5,7 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <title>The Grey — board</title>
   <link href="https://fonts.googleapis.com/css2?family=Cormorant+Garamond:wght@400;600&family=Crimson+Text:wght@600&display=swap" rel="stylesheet">
-  <link rel="stylesheet" href="./styles.css?v=mlv22-20260509" />
+  <link rel="stylesheet" href="./styles.css?v=mlv23-20260509" />
 </head>
 <body id="board" class="theme-dark parchment">
 
@@ -164,7 +164,7 @@
     </div>
   </div>
 
-  <script type="module" src="./index.js?v=mlv22-20260509"></script>
+  <script type="module" src="./index.js?v=mlv23-20260509"></script>
 </body>
 
 </html>

--- a/index.js
+++ b/index.js
@@ -4377,26 +4377,47 @@ function ensureRightHudStrip() {
   if (!strip) {
     strip = document.createElement('div');
     strip.id = id;
-    Object.assign(strip.style, {
-      position: 'fixed',
-      right: '16px',
-      bottom: '16px',
-      display: 'flex',
-      flexDirection: 'column',
-      gap: '10px',
-      zIndex: '1200',
-    });
     document.body.appendChild(strip);
   }
 
-  // desired order top→bottom
+  // v23: layout responds to body.mobile-portrait. v22 added CSS rules
+  // for a top-right horizontal cluster, but this function had been
+  // pinning the strip at bottom-right with inline styles, overriding
+  // them. Now we apply per-orientation inline styles so the strip
+  // moves to the top-right on portrait phones (where it had been
+  // overlapping the rightmost flow card and the player glyph slot).
+  const isPortrait = document.body.classList.contains('mobile-portrait');
+  Object.assign(strip.style, isPortrait ? {
+    position: 'fixed',
+    top: '6px',
+    right: '6px',
+    bottom: 'auto',
+    left: 'auto',
+    display: 'flex',
+    flexDirection: 'row',
+    gap: '6px',
+    zIndex: '1200',
+  } : {
+    position: 'fixed',
+    top: 'auto',
+    right: '16px',
+    bottom: '16px',
+    left: 'auto',
+    display: 'flex',
+    flexDirection: 'column',
+    gap: '10px',
+    zIndex: '1200',
+  });
+
   const order = ['btn-endturn-hud', 'btn-discard-hud', 'btn-deck-hud'];
 
   order.forEach(btnId => {
     const n = document.getElementById(btnId);
     if (!n) return;
 
-    // hard reset any legacy positioning so the flex strip controls layout
+    // Hard-reset legacy positioning so the strip's flex layout controls it.
+    // End Turn stays slightly larger as the most-tapped action.
+    const isEndTurn = btnId === 'btn-endturn-hud';
     Object.assign(n.style, {
       position: 'static',
       top: '', right: '', bottom: '', left: '',
@@ -4404,9 +4425,9 @@ function ensureRightHudStrip() {
       transform: 'none',
       display: 'grid',
       placeItems: 'center',
-      width: '52px',
-      height: '52px',
-      borderRadius: '12px',
+      borderRadius: isPortrait ? '10px' : '12px',
+      width:  isPortrait ? (isEndTurn ? '48px' : '36px') : '52px',
+      height: isPortrait ? '36px' : '52px',
       pointerEvents: 'auto'
     });
 

--- a/styles.css
+++ b/styles.css
@@ -2916,40 +2916,43 @@ body.mobile-landscape .wincon-rail .hp-bar-host .hp-num {
 
 /* Stripe: a thin bar on the LEFT EDGE of every card, full height.
    Lives inside .card content; CSS pins it absolutely. */
+/* v23: stripe bumped 4px → 7px and given a soft outward glow so the
+   school identity reads even on shrunken hand cards. */
 .card .school-stripe {
   position: absolute;
   left: 0; top: 0; bottom: 0;
-  width: 4px;
+  width: 7px;
   border-radius: 8px 0 0 8px;
   pointer-events: none;
   z-index: 2;
 }
 .card .school-stripe.school-black {
-  background: linear-gradient(180deg, #1a0c0c 0%, #5a1a1a 50%, #1a0c0c 100%);
-  box-shadow: inset 1px 0 0 rgba(217,122,122,.35);
+  background: linear-gradient(180deg, #2a0a0a 0%, #8a2a2a 50%, #2a0a0a 100%);
+  box-shadow: inset 1px 0 0 rgba(255,140,140,.55), 1px 0 6px rgba(180,40,40,.4);
 }
 .card .school-stripe.school-white {
-  background: linear-gradient(180deg, #d8c89a 0%, #f3e4b3 50%, #b8a572 100%);
-  box-shadow: inset 1px 0 0 rgba(255,240,200,.55);
+  background: linear-gradient(180deg, #c8b478 0%, #f5e6b8 50%, #a89460 100%);
+  box-shadow: inset 1px 0 0 rgba(255,240,200,.75), 1px 0 6px rgba(220,200,140,.45);
 }
 .card .school-stripe.school-grey {
-  background: linear-gradient(180deg, #404048 0%, #707080 50%, #303038 100%);
-  box-shadow: inset 1px 0 0 rgba(180,185,200,.25);
+  background: linear-gradient(180deg, #4a4a52 0%, #8a8a96 50%, #383840 100%);
+  box-shadow: inset 1px 0 0 rgba(200,205,220,.45), 1px 0 4px rgba(140,145,160,.3);
 }
 
-/* Whole-frame subtle tint via :has() — modern browsers support it.
-   We keep the tint small so card text stays readable. */
+/* Whole-frame tint via :has() — pulls the school colour into the card
+   border + a faint top-edge gradient so the colour reads even when
+   the stripe itself is partially covered by adjacent cards in hand. */
 .card:has(.school-stripe.school-black) {
-  border-color: rgba(140,40,40,.45);
-  background-image: linear-gradient(180deg, rgba(40,8,8,.18) 0%, transparent 40%);
+  border-color: rgba(180,60,60,.7) !important;
+  background-image: linear-gradient(180deg, rgba(60,12,12,.28) 0%, transparent 50%);
 }
 .card:has(.school-stripe.school-white) {
-  border-color: rgba(200,180,120,.55);
-  background-image: linear-gradient(180deg, rgba(220,200,140,.10) 0%, transparent 40%);
+  border-color: rgba(220,200,130,.75) !important;
+  background-image: linear-gradient(180deg, rgba(230,210,150,.18) 0%, transparent 50%);
 }
 .card:has(.school-stripe.school-grey) {
-  border-color: rgba(120,125,140,.45);
-  /* Grey is the neutral default — no tint, lets existing palette dominate. */
+  border-color: rgba(150,155,170,.55);
+  /* Grey is the neutral default — no surface tint, lets existing palette dominate. */
 }
 
 /* Rail token badges (Ward, Free Buy). Inline, compact. */


### PR DESCRIPTION
User screenshot of v22 surfaced two visible problems with a one-word brief: *"Look to improve."*

## 1. HUD didn't relocate (regression)

End Turn / Deck / Discard were still in the bottom-right corner overlapping the rightmost flow card and the player's glyph slot — the **exact issue v22 was supposed to fix**.

**Root cause:** `ensureRightHudStrip()` (`index.js:4374`, runs every render) creates a `#hud-right-strip` div, *moves* the 3 buttons out of `<aside class="hud">` into it, and pins them with **inline styles** at `right:16px / bottom:16px`. v22's mobile-portrait CSS targeted `.hud`, which becomes empty after the move. Inline styles always win against stylesheet rules without `!important`.

**Fix:** `ensureRightHudStrip` now reads `body.mobile-portrait` and applies per-orientation inline styles. On portrait phones the strip pins at `top:6px right:6px` as a horizontal flex row with End Turn (48×36) leading and Deck/Discard (36×36) trailing. Desktop / landscape behaviour unchanged.

## 2. School stripes barely visible

The 4px left-edge stripe added in v21 was too thin to read on small hand cards under typical screen brightness. The school identity feature wasn't doing its job at a glance.

**Fix:**
- Stripe widened 4 → 7px
- Soft outward glow per school (red glow on Black, gold glow on White, neutral on Grey)
- Brighter `:has()` frame border tints — alpha 0.45 → 0.7 — so the school colour still reads when an adjacent card in hand partially covers the stripe edge

## Files

| File | Change |
|---|---|
| `index.js` | `ensureRightHudStrip` reads body class; per-orientation inline styles for the strip and per-button sizing |
| `styles.css` | `.school-stripe` width 4→7px + glows; `:has()` frame tints with `!important` and stronger alpha |
| `index.html` | Cache-bust `mlv23-20260509` |

Single squashable commit `9faecba`.

---
_Generated by [Claude Code](https://claude.ai/code/session_01C1TYVtozydzcqvzpY15HMA)_