### PR TITLE
v24: tone down stripes + MTG-Arena-style press-and-hold peek

### DIFF
--- a/index.html
+++ b/index.html
@@ -5,7 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <title>The Grey — board</title>
   <link href="https://fonts.googleapis.com/css2?family=Cormorant+Garamond:wght@400;600&family=Crimson+Text:wght@600&display=swap" rel="stylesheet">
-  <link rel="stylesheet" href="./styles.css?v=mlv23-20260509" />
+  <link rel="stylesheet" href="./styles.css?v=mlv24-20260509" />
 </head>
 <body id="board" class="theme-dark parchment">
 
@@ -164,7 +164,7 @@
     </div>
   </div>
 
-  <script type="module" src="./index.js?v=mlv23-20260509"></script>
+  <script type="module" src="./index.js?v=mlv24-20260509"></script>
 </body>
 
 </html>

--- a/index.js
+++ b/index.js
@@ -2312,25 +2312,32 @@ const LONG_PRESS_MS=500, MOVE_CANCEL_PX=8;
 // v19: expose so the drag handler can suppress peek the moment a
 // drag-eligible touch lands. Without this, a 350-500ms hold would
 // pop the peek overlay over the very card being dragged.
+// v24: also toggles `body.peek-open` so CSS can dim the backdrop
+// (MTG-Arena-style enlargement: only the peeked card stays bright).
 function cancelPeek(){
   if (longPressTimer) { clearTimeout(longPressTimer); longPressTimer = null; }
   peekEl?.classList.remove("show");
+  document.body.classList.remove("peek-open");
+}
+function showPeek(data){
+  if (!peekEl) return;
+  fillCardShell(peekEl, data);
+  peekEl.classList.add("show");
+  document.body.classList.add("peek-open");
 }
 
 function attachPeekAndZoom(el, data){
   if (peekEl){
-    el.addEventListener("mouseenter", ()=>{ fillCardShell(peekEl, data); peekEl.classList.add("show"); });
-    el.addEventListener("mouseleave", ()=>{ peekEl.classList.remove("show"); });
+    el.addEventListener("mouseenter", ()=>{ showPeek(data); });
+    el.addEventListener("mouseleave", ()=>{ cancelPeek(); });
   }
   const onDown = (ev)=>{
     if (longPressTimer) clearTimeout(longPressTimer);
     const t = ev.clientX!==undefined?ev:(ev.touches?.[0]??{clientX:0,clientY:0});
     pressStart = {x:t.clientX,y:t.clientY};
-    longPressTimer = setTimeout(()=>{
-      if (peekEl){ fillCardShell(peekEl, data); peekEl.classList.add("show"); }
-    }, LONG_PRESS_MS);
+    longPressTimer = setTimeout(()=>{ showPeek(data); }, LONG_PRESS_MS);
   };
-  const clearLP = ()=>{ if (longPressTimer){ clearTimeout(longPressTimer); longPressTimer=null; } peekEl?.classList.remove("show"); };
+  const clearLP = ()=>{ cancelPeek(); };
   const onMove = (ev)=>{
     const t = ev.clientX!==undefined?ev:(ev.touches?.[0]??{clientX:0,clientY:0});
     if (Math.hypot(t.clientX-pressStart.x, t.clientY-pressStart.y) > MOVE_CANCEL_PX) clearLP();
@@ -2967,11 +2974,12 @@ function wireTouchDrag(el, data){
     primed = true;
     touchStartTime = performance.now();
     touchStartX = t.clientX; touchStartY = t.clientY;
-    // v19: as soon as a drag-eligible touch lands on a hand card,
-    // suppress the long-press peek timer. Peek still fires if the
-    // user holds COMPLETELY STILL through the 8px threshold and the
-    // 500ms long-press window — but any drag-intent kills it early.
-    cancelPeek();
+    // v24: do NOT cancel the peek timer here. v19 had killed it on
+    // every touch, which made press-and-hold (MTG Arena style) never
+    // fire on hand cards because attachPeekAndZoom's pointerdown
+    // timer got clobbered. Peek now fires after 500ms of HOLDING
+    // STILL; only the actual start of a drag (>8px movement →
+    // beginDrag) kills it.
   }, {passive:true});
 
   el.addEventListener("touchmove", (ev)=>{

--- a/styles.css
+++ b/styles.css
@@ -2917,7 +2917,11 @@ body.mobile-landscape .wincon-rail .hp-bar-host .hp-num {
 /* Stripe: a thin bar on the LEFT EDGE of every card, full height.
    Lives inside .card content; CSS pins it absolutely. */
 /* v23: stripe bumped 4px → 7px and given a soft outward glow so the
-   school identity reads even on shrunken hand cards. */
+   school identity reads even on shrunken hand cards.
+   v24: outward glow removed — it cast a 6px haze INTO the card content
+   area making titles/text hazy. Stripe still 7px but contained; the
+   :has() frame tint carries the school identity without bleeding into
+   the textbox. */
 .card .school-stripe {
   position: absolute;
   left: 0; top: 0; bottom: 0;
@@ -2928,31 +2932,31 @@ body.mobile-landscape .wincon-rail .hp-bar-host .hp-num {
 }
 .card .school-stripe.school-black {
   background: linear-gradient(180deg, #2a0a0a 0%, #8a2a2a 50%, #2a0a0a 100%);
-  box-shadow: inset 1px 0 0 rgba(255,140,140,.55), 1px 0 6px rgba(180,40,40,.4);
+  box-shadow: inset 1px 0 0 rgba(255,140,140,.55);
 }
 .card .school-stripe.school-white {
   background: linear-gradient(180deg, #c8b478 0%, #f5e6b8 50%, #a89460 100%);
-  box-shadow: inset 1px 0 0 rgba(255,240,200,.75), 1px 0 6px rgba(220,200,140,.45);
+  box-shadow: inset 1px 0 0 rgba(255,240,200,.75);
 }
 .card .school-stripe.school-grey {
   background: linear-gradient(180deg, #4a4a52 0%, #8a8a96 50%, #383840 100%);
-  box-shadow: inset 1px 0 0 rgba(200,205,220,.45), 1px 0 4px rgba(140,145,160,.3);
+  box-shadow: inset 1px 0 0 rgba(200,205,220,.45);
 }
 
-/* Whole-frame tint via :has() — pulls the school colour into the card
-   border + a faint top-edge gradient so the colour reads even when
-   the stripe itself is partially covered by adjacent cards in hand. */
+/* v24: tints further dialled back so the school identity is a quiet
+   secondary cue, not a competing layer with the card text. Border is
+   still tinted (alpha .45 instead of .7) but the background gradient
+   is removed for Black + White too — the stripe alone carries the
+   colour, and the textbox stays neutral and readable. */
 .card:has(.school-stripe.school-black) {
-  border-color: rgba(180,60,60,.7) !important;
-  background-image: linear-gradient(180deg, rgba(60,12,12,.28) 0%, transparent 50%);
+  border-color: rgba(180,60,60,.45) !important;
 }
 .card:has(.school-stripe.school-white) {
-  border-color: rgba(220,200,130,.75) !important;
-  background-image: linear-gradient(180deg, rgba(230,210,150,.18) 0%, transparent 50%);
+  border-color: rgba(220,200,130,.50) !important;
 }
 .card:has(.school-stripe.school-grey) {
-  border-color: rgba(150,155,170,.55);
-  /* Grey is the neutral default — no surface tint, lets existing palette dominate. */
+  border-color: rgba(150,155,170,.40);
+  /* Grey is the neutral default — no surface tint. */
 }
 
 /* Rail token badges (Ward, Free Buy). Inline, compact. */
@@ -3075,3 +3079,53 @@ body.mobile-portrait #btn-deck-hud    { order: 2; }
   padding: 1px 5px;
   pointer-events: none;
 }
+
+
+/* ==========================================================
+   v24: PEEK = press-and-hold-to-enlarge (MTG-Arena-style)
+   - body.peek-open dims the rest of the screen so only the
+     enlarged card is bright (the textbox finally readable
+     at the size it deserves).
+   - Peek card gets a stronger drop-shadow + hard outline so
+     it floats clearly above the dimmed backdrop.
+   ========================================================== */
+
+/* Backdrop dim. We dim the play area (#board-grid + .hud) and the
+   hand band, but NOT #preview-layer (which contains #peek-card),
+   so the enlarged card stays at full brightness. */
+body.peek-open #board-grid,
+body.peek-open #hud-right-strip,
+body.peek-open .hud,
+body.peek-open .hand-wrap,
+body.peek-open .hand,
+body.peek-open #ai-mini,
+body.peek-open .menu-btn,
+body.peek-open #weaver-backdrop {
+  filter: brightness(0.32) saturate(0.6);
+  transition: filter .14s ease;
+  pointer-events: none;
+}
+body:not(.peek-open) #board-grid,
+body:not(.peek-open) #hud-right-strip,
+body:not(.peek-open) .hud,
+body:not(.peek-open) .hand-wrap,
+body:not(.peek-open) .hand,
+body:not(.peek-open) #ai-mini {
+  transition: filter .12s ease;
+}
+
+/* Peek card itself: bigger on phones (was 2× scale; bump to ~70vw) and
+   given a stronger separation from the dimmed backdrop. */
+body.mobile-portrait #peek-card.card.peek,
+body.mobile-landscape #peek-card.card.peek {
+  width: min(78vw, 380px) !important;
+  height: auto !important;
+  aspect-ratio: 1 / 1.4 !important;
+  box-shadow: 0 24px 56px rgba(0,0,0,.75),
+              0 0 0 2px rgba(198,165,106,.55),
+              0 0 36px rgba(198,165,106,.25) !important;
+}
+
+/* Release-to-close — handled in JS by pointerup/leave/cancel on the
+   peeked card (attachPeekAndZoom). Press-and-hold to read; release
+   to dismiss. Matches MTG Arena's press-to-zoom pattern. */


### PR DESCRIPTION
User: *"Look at more improvements. There's still a lot that needs to be done. Maybe it's like MTG arena where the top on the card / press and hold makes the card grow in size so you can read it better. The stripe makes the card illegible and can't tell the difference in cards."*

## Two problems both diagnosed in code, both fixed.

### 1. The stripe was hazing the card content

v23 added an outward box-shadow on `.school-stripe`:

```css
box-shadow: inset ..., 1px 0 6px rgba(180,40,40,.4);
```

That `1px 0 6px` is a 6px-blur shadow casting **into** the card content area. That's the haze the user saw — it made titles and rules text look out of focus. The `:has()` frame tints (alpha .7) and surface gradient also added a competing colour layer.

**Fix:**
- Outward glow removed entirely; only the inset highlight on the stripe itself remains
- `:has()` border alpha .7 → .45
- Surface gradient overlay removed for Black + White too
- Stripe still 7px wide for school readability, but now contained — school identity is a quiet secondary cue, not a competing layer with the card text

### 2. Press-and-hold peek never fired on hand cards

v19 had `wireTouchDrag.touchstart` unconditionally call `cancelPeek()`, which clears the long-press timer set by `attachPeekAndZoom`'s `pointerdown`. Both run on every touch, so the peek timer was clobbered before it could fire — MTG-Arena-style press-and-hold-to-read just didn't work on hand cards.

**Fix:** `touchstart` no longer cancels peek. The timer now fires after 500ms of holding still; only an actual drag start (>8px movement → `beginDrag`) cancels it. That's the correct gate.

### Plus: peek now dims the backdrop

- New `body.peek-open` class toggled by `showPeek` / `cancelPeek`
- CSS dims `#board-grid`, `.hud`, `#hud-right-strip`, `.hand-wrap`, `#ai-mini`, `.menu-btn`, `#weaver-backdrop` to `brightness(0.32) saturate(0.6)` while peek is open
- Peek card bumped to `min(78vw, 380px)` on mobile, stronger drop-shadow + gold outline so it floats clearly above the dimmed backdrop
- Press-and-hold to read; release dismisses (matches MTG Arena pattern)

## Files

| File | Change |
|---|---|
| `index.js` | `cancelPeek()` removed from `wireTouchDrag.touchstart`; new `showPeek(data)` helper toggles `body.peek-open`; `cancelPeek` clears the class too |
| `styles.css` | Stripe outward glow removed; `:has()` tints toned down; new `body.peek-open` backdrop-dim block; peek card sizing + shadow boosted on mobile |
| `index.html` | Cache-bust `mlv24-20260509` |

Single squashable commit `ec0a36b`.

---
_Generated by [Claude Code](https://claude.ai/code/session_01C1TYVtozydzcqvzpY15HMA)_