### PR TITLE
v26: playtest fixes — 6 functional defects + 3 UX issues

### DIFF
--- a/GameLogic.js
+++ b/GameLogic.js
@@ -364,6 +364,37 @@ function applyReactionEffect(state, reactionCard, trigger, context, reactingSide
       });
     }
   }
+  // v26: Spite Wisp — when opponent plays a Spell, Hex that Spell Slot
+  // AND deal 1 damage to the caster. Reuses the Hexing Wisp pathway
+  // for the hex half so behaviour stays consistent with the base card.
+  else if (reactionCard?.name === 'Spite Wisp' &&
+           trigger === 'spell_cast' &&
+           context?.cardId) {
+    const casterSide    = context.playerId;
+    const opponentSlots = state.players?.[casterSide]?.slots || [];
+    for (let i = 0; i < opponentSlots.length; i++) {
+      const slot = opponentSlots[i];
+      const c    = slot?.card;
+      if (slot?.hasCard && c?.id === context.cardId && c?.type === "SPELL") {
+        state = applyHexToSlot(state, reactingSide, casterSide, i, /*durationTurns=*/2);
+        break;
+      }
+    }
+    state = dealDamage(state, casterSide, 1, { source: "reaction", cardId: reactionCard?.id });
+  }
+  // v26: Mercy of the Flow — when opponent deals damage, heal 2 + draw 1.
+  // White school's defining reactive defense card; broken since v21
+  // because applyReactionEffect dispatches on hardcoded card name.
+  else if (reactionCard?.name === 'Mercy of the Flow' && trigger === 'damage') {
+    const P = state.players?.[reactingSide];
+    if (P) {
+      const maxVitality = typeof STARTING_VITALITY !== 'undefined' ? STARTING_VITALITY : 12;
+      P.vitality = Math.min(maxVitality, (P.vitality | 0) + 2);
+      pushEvt(state, { t: 'heal', side: reactingSide, amount: 2, by: reactionCard?.id });
+      state = drawN(state, reactingSide, 1);
+      pushEvt(state, { t: 'draw', side: reactingSide, amount: 1, by: reactionCard?.id });
+    }
+  }
   return state;
 }
 
@@ -1245,9 +1276,12 @@ export function dealDamage(state, targetSide, amount = 1, meta = {}) {
 
   // v21 — Ward consumption. One ward absorbs the entire incoming
   // damage instance (matches Slay-the-Spire-style block where small
-  // hits and big hits are both eaten). If the consumer wants per-
-  // point absorption later we can switch to `n -= used; wards -= used`.
-  if ((P.wards | 0) > 0) {
+  // hits and big hits are both eaten).
+  // v26: self-sourced damage (Morr's Last Rites sacrifice, future
+  // "lose N vitality" effects) bypasses wards. A ward is defence
+  // against the opponent, not a free pass on your own ritual cost.
+  const isSelfSource = meta.source === "self";
+  if (!isSelfSource && (P.wards | 0) > 0) {
     P.wards = Math.max(0, (P.wards | 0) - 1);
     pushEvt(state, { t: "ward_consumed", side: targetSide, absorbed: n, source: meta.source, cardId: meta.cardId });
     return state;
@@ -2085,6 +2119,22 @@ function applyGlyphPassives(state, side, trigger){
     const mDmg = text.match(/when\s+a\s+spell\s+resolves?\s*→?\s*deal\s+(\d+)\s+damage/);
     if (mDmg) {
       state = dealDamage(state, otherSide(side), +mDmg[1], { source: "glyph", cardId: slot.card?.id });
+      fired = true;
+    }
+    // v26: "When a Spell resolves → Gain a Ward" (Aegis Glyph). The v21
+    // parser handles "Gain a Ward" on plain card text (instants/spells
+    // resolving via applyParsedEffects), but the glyph-passive trigger
+    // path doesn't go through applyParsedEffects — it pattern-matches
+    // here, so each new outcome needs its own arm.
+    if (/when\s+a\s+spell\s+resolves?\s*→?\s*gain\s+(?:a|an|\d+)\s*wards?/.test(text)) {
+      state.players[side].wards = (state.players[side].wards | 0) + 1;
+      pushEvt(state, { t: "ward_gained", side, amount: 1, by: slot.card?.id });
+      fired = true;
+    }
+    // v26: "When a Spell resolves → Gain a Free Buy" (Convergence Mark).
+    if (/when\s+a\s+spell\s+resolves?\s*→?\s*gain\s+(?:a|an|\d+)\s*free\s*buys?/.test(text)) {
+      state.players[side].bonusBuys = (state.players[side].bonusBuys | 0) + 1;
+      pushEvt(state, { t: "bonus_buy_gained", side, amount: 1, by: slot.card?.id });
       fired = true;
     }
   }

--- a/index.html
+++ b/index.html
@@ -5,7 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <title>The Grey — board</title>
   <link href="https://fonts.googleapis.com/css2?family=Cormorant+Garamond:wght@400;600&family=Crimson+Text:wght@600&display=swap" rel="stylesheet">
-  <link rel="stylesheet" href="./styles.css?v=mlv25-20260509" />
+  <link rel="stylesheet" href="./styles.css?v=mlv26-20260509" />
 </head>
 <body id="board" class="theme-dark parchment">
 
@@ -164,7 +164,7 @@
     </div>
   </div>
 
-  <script type="module" src="./index.js?v=mlv25-20260509"></script>
+  <script type="module" src="./index.js?v=mlv26-20260509"></script>
 </body>
 
 </html>

--- a/index.js
+++ b/index.js
@@ -2205,7 +2205,18 @@ function layoutHand(container, cards) {
   const cw = cards[0]?.clientWidth || container.clientWidth / Math.max(1, N);
   // Tighter overlap on mobile so wider hands fit without running off
   // the edges; desktop kept at .98.
-  const stepX = cw * (isMobile ? 0.82 : 0.98);
+  // v26: also clamp stepX so the hand never overflows the container
+  // when N grows large. Without this, 7+ cards on a narrow phone band
+  // stacked so heavily that the focused card's neighbours were
+  // unreadable. We compute the available width (container minus one
+  // card width and a small breathing margin), divide by (N-1), and
+  // pick the SMALLER of (idealStep, fitStep) so cards fan tighter
+  // only when they have to.
+  const idealStep = cw * (isMobile ? 0.82 : 0.98);
+  const containerW = container.clientWidth || window.innerWidth;
+  const padded = Math.max(cw, containerW - cw - 24);
+  const fitStep = N > 1 ? padded / (N - 1) : 0;
+  const stepX = N > 1 ? Math.min(idealStep, fitStep) : 0;
   const startX = -stepX * (N-1) / 2;
   const LIFT = isML ? 14 : isMP ? 24 : 44;
 
@@ -2758,16 +2769,36 @@ await render();
   document.body.appendChild(pop);
   // Ensure reaction popovers appear above the dimming overlay and other UI
   pop.style.zIndex = 3600;
-  // On mobile (both orientations) the action-pop is styled as a fixed
-  // bottom sheet (see styles.css). Skip the per-card positioning so
-  // CSS controls layout.
-  const isMobilePortrait = document.body?.classList?.contains('mobile-portrait');
-  if (!isMobileLandscape() && !isMobilePortrait){
-    const r = cardEl.getBoundingClientRect();
-    pop.style.left = `${r.left + r.width/2}px`;
-    pop.style.top  = `${r.top  - 12}px`;
-    pop.style.transform = "translate(-50%, -100%)";
-  }
+  // v26: anchor the popover above the focused card on EVERY breakpoint.
+  // Was: mobile fell back to a fixed 92vw bottom sheet that visually
+  // covered hand cards on portrait phones. Now the popover floats just
+  // above whichever card the user tapped, falling below if there isn't
+  // room (only matters for cards near the top of the viewport).
+  pop.style.position = 'fixed';
+  pop.style.bottom = 'auto';
+  pop.style.transform = 'none';
+  // Let the popover size itself first so we can read offsetHeight/Width.
+  // It's already in the DOM at this point.
+  const popW = pop.offsetWidth || 320;
+  const popH = pop.offsetHeight || 64;
+  const r = cardEl.getBoundingClientRect();
+  const cx = r.left + r.width / 2;
+  const margin = 8;
+  const vw = window.innerWidth;
+  const vh = window.innerHeight;
+
+  let left = Math.round(cx - popW / 2);
+  left = Math.max(margin, Math.min(left, vw - popW - margin));
+
+  // Prefer above the card; if the card is too close to the top, fall below.
+  const aboveTop = r.top - popH - 12;
+  const belowTop = r.bottom + 12;
+  const top = (aboveTop >= margin)
+    ? aboveTop
+    : Math.min(belowTop, vh - popH - margin);
+
+  pop.style.left = `${left}px`;
+  pop.style.top  = `${Math.max(margin, top)}px`;
 }
 
 
@@ -3131,6 +3162,14 @@ function renderSlots(container, snapshot, isPlayer){
 
     // reflect occupancy so CSS can undim when a card is present
     d.classList.toggle('has-card', !!(slot.hasCard && slot.card));
+    // v26: stamp the placed card's school so the slot frame can paint
+    // a school-coloured ring (the .card's own inset shadow gets clipped
+    // by .slot { overflow: hidden }, so we mirror it on the slot itself).
+    if (slot.hasCard && slot.card) {
+      d.dataset.school = (slot.card.school || 'grey').toLowerCase();
+    } else {
+      delete d.dataset.school;
+    }
     if (slot.hasCard && slot.card){
       const art = document.createElement("article");
         art.className = "card";
@@ -3194,6 +3233,14 @@ g.tabIndex = 0; // for :focus-within keyboard reveal
 // current glyph data
 const glyphSlot = safe[3] || { isGlyph: true, hasCard: false, card: null };
 g.classList.toggle("has-card", !!(glyphSlot.hasCard && glyphSlot.card));
+// v26: school-coloured ring on the glyph slot when set (mirrors the
+// spell-slot treatment above so placed glyphs read their school
+// identity from across the screen).
+if (glyphSlot.hasCard && glyphSlot.card) {
+  g.dataset.school = (glyphSlot.card.school || 'grey').toLowerCase();
+} else {
+  delete g.dataset.school;
+}
 
 // ---------- EMPTY: placeholder wrapper (title centered over rune) ----------
 if (!glyphSlot.hasCard || !glyphSlot.card) {
@@ -4388,13 +4435,20 @@ function ensureRightHudStrip() {
     document.body.appendChild(strip);
   }
 
-  // v23: layout responds to body.mobile-portrait. v22 added CSS rules
-  // for a top-right horizontal cluster, but this function had been
-  // pinning the strip at bottom-right with inline styles, overriding
-  // them. Now we apply per-orientation inline styles so the strip
-  // moves to the top-right on portrait phones (where it had been
-  // overlapping the rightmost flow card and the player glyph slot).
-  const isPortrait = document.body.classList.contains('mobile-portrait');
+  // v23: layout responds to mobile-portrait. v22 added CSS rules for a
+  // top-right horizontal cluster, but this function had been pinning
+  // the strip at bottom-right with inline styles, overriding them.
+  // v26: read the viewport DIRECTLY rather than trusting body.mobile-
+  // portrait. The orientation handler that sets that class runs as an
+  // IIFE alongside DOMContentLoaded; on first paint there was a race
+  // where this could run before the class was set, so the strip would
+  // briefly appear bottom-right before render() relocated it. Reading
+  // window dimensions matches the orientation IIFE's own logic
+  // (w<=720 && h>w) so the first paint already lands top-right.
+  const isPortrait = (() => {
+    const w = window.innerWidth, h = window.innerHeight;
+    return w <= 720 && h > w;
+  })();
   Object.assign(strip.style, isPortrait ? {
     position: 'fixed',
     top: '6px',

--- a/styles.css
+++ b/styles.css
@@ -965,15 +965,16 @@ body.mobile-landscape #btn-endturn-hud{
   display: grid; place-items: center;
 }
 
-/* ===== Bottom action sheet (replaces tiny popover) ===== */
+/* v26: action popover styling. The fixed-bottom-sheet positioning was
+   removed (used to be 92vw at bottom: hand-band+8px) so showCardOptions
+   in JS can anchor the popover ABOVE the focused card on every break-
+   point. Visual styling stays; positioning is now controlled per-tap.
+   Width capped tighter (min(360px, 80vw)) so a card-anchored popover
+   doesn't span the screen when the focused card is near an edge. */
 body.mobile-landscape .action-pop,
 body.mobile-portrait  .action-pop{
-  position: fixed !important;
-  left: 50% !important;
-  bottom: calc(var(--hand-band-h) + 8px) !important;
-  top: auto !important;
-  transform: translateX(-50%) !important;
-  width: min(420px, 92vw); padding: 10px 12px;
+  position: fixed;
+  width: min(360px, 80vw); padding: 10px 12px;
   display: flex; gap: 10px; justify-content: center; align-items: center;
   background: linear-gradient(180deg,#2a211a,#1a140f);
   border: 1px solid #5a4b37; border-radius: 14px;
@@ -3114,3 +3115,23 @@ body.mobile-landscape #peek-card.card.peek {
 /* Release-to-close — handled in JS by pointerup/leave/cancel on the
    peeked card (attachPeekAndZoom). Press-and-hold to read; release
    to dismiss. Matches MTG Arena's press-to-zoom pattern. */
+
+
+/* ==========================================================
+   v26: SLOT-LEVEL school border (the v25 inset shadow on .card
+   gets clipped by .slot { overflow: hidden }, so we mirror the
+   ring on the slot itself once a card lands).
+   ========================================================== */
+
+.slot[data-school="black"] {
+  box-shadow: inset 0 0 0 3px rgba(168, 50, 50, .92);
+  border-color: rgba(168, 50, 50, .92);
+}
+.slot[data-school="white"] {
+  box-shadow: inset 0 0 0 3px rgba(214, 185, 102, .92);
+  border-color: rgba(214, 185, 102, .92);
+}
+.slot[data-school="grey"] {
+  box-shadow: inset 0 0 0 3px rgba(124, 136, 152, .80);
+  border-color: rgba(124, 136, 152, .80);
+}


### PR DESCRIPTION
User: *"There are still of issues. Playtest it."*

A two-track audit (UX visual + gameplay logic) found one **blocker** explaining the persistent "school color didn't work" complaint at a deeper level than v25 addressed, **four cards that silently no-op** in the current engine, a **sacrifice/ward interaction bug**, and three minor UX issues the user folded into scope.

## Functional defects (6)

### B1 — BLOCKER: school border invisible on cards in slots

v25 put the school identity on `.card { box-shadow: inset ... }`, but `.slot { overflow: hidden }` (`styles.css:121`) clips that inset shadow to nothing. Cards in spell + glyph slots — i.e. most of what the player actually looks at during a match — rendered with no school colour. **v25 only worked in hand.**

**Fix:** stamp `slot.dataset.school` from the placed card's school in `renderSlots` (both spell row + glyph row). CSS paints a matching inset 3px ring on `.slot[data-school="X"]`. Mirrors v25's `.card` visual treatment so placed cards now read their school identity from across the screen.

### B2 — Aegis Glyph (White) was a no-op
*"When a Spell resolves → Gain a Ward"* — `applyGlyphPassives.spell_resolved` only knew about Aether and Damage outcomes. Added a Ward regex arm.

### B3 — Convergence Mark (Grey × Confluence) was a no-op
*"When a Spell resolves → Gain a Free Buy"* — same parser gap. Added matching regex arm for `bonusBuys`.

### B4 — Spite Wisp (broken since v6!)
REACTION *"Hex Slot + Deal 1 damage"* had no case in `applyReactionEffect`'s hardcoded if/else. Added a case that reuses `applyHexToSlot` for the hex half + `dealDamage` for the 1 damage.

### B5 — Mercy of the Flow (White's defining defensive reaction)
*"When opponent deals damage → Heal 2 + Draw 1"* had no case. Added a `damage` trigger arm that heals (capped at `STARTING_VITALITY`) and draws via existing `drawN`.

### B6 — wards absorbed self-sacrifice damage
Morr's Stage II Last Rites does `dealDamage` with `source: "self"` to bleed the caster. v21's ward check absorbed it, undermining Black-school identity. Gated ward consumption on `meta.source !== "self"`.

## UX (3, user-folded-in)

### B7 — hand-card overlap at 7+ cards
`layoutHand` `stepX` was a fixed `cw*0.82` on portrait. Many cards on a narrow band → siblings stacked so heavily the focused card's neighbours were unreadable. Now `stepX = min(idealStep, fitStep)` where `fitStep = (containerW - cw - 24) / (N-1)`. Cards fan tighter as N grows, never overflow.

### B8 — action popover overlapping hand cards
Mobile CSS pinned `.action-pop` at `bottom: hand-band+8px / 92vw` with `!important` — a fixed bottom sheet that covered hand cards on portrait. Removed `!important` on positioning; `showCardOptions` now anchors the popover above the focused card on every breakpoint (falls below if the card is too close to viewport top). Width capped at `min(360px, 80vw)`.

### B9 — HUD-strip boot race
`ensureRightHudStrip` read `body.mobile-portrait`, set by an IIFE alongside `DOMContentLoaded`. First paint could land bottom-right before `render()` corrected it. Now reads `window.innerWidth/innerHeight` directly using the same threshold as the orientation IIFE (`w<=720 && h>w`), so first paint lands in the right corner regardless of class-set order.

## Files

| File | Change |
|---|---|
| `GameLogic.js` ~289 (`applyReactionEffect`) | Spite Wisp + Mercy of the Flow handlers (B4, B5) |
| `GameLogic.js` ~1248 (`dealDamage`) | Ward bypass on `source: "self"` (B6) |
| `GameLogic.js` ~2075 (`applyGlyphPassives` `spell_resolved`) | Ward + BonusBuy regex arms (B2, B3) |
| `index.js` ~3133 + ~3196 (renderSlots) | Stamp `slot.dataset.school` (B1) |
| `index.js` ~2208 (`layoutHand`) | `stepX` clamp to container width (B7) |
| `index.js` ~2769 (`showCardOptions`) | Anchor above focused card on every breakpoint (B8) |
| `index.js` ~4395 (`ensureRightHudStrip`) | Read viewport directly, not body class (B9) |
| `styles.css` | `.slot[data-school]` rules (B1); `.action-pop` !important removed on positioning (B8) |
| `index.html` | Cache-bust `mlv26-20260509` |

Single squashable commit `77af84d`.

---
_Generated by [Claude Code](https://claude.ai/code/session_01C1TYVtozydzcqvzpY15HMA)_