### PR TITLE
v27: AI capability + feedback signaling + polish (full sweep)

### DIFF
--- a/ai.js
+++ b/ai.js
@@ -114,17 +114,28 @@ export async function runAiTurn(state, api) {
   }
 
   // ── 2) SET or REPLACE a Glyph ────────────────────────────────
-  // Glyphs are persistent now. Set freely when slot is open.
-  // In kill mode, swap to a damage glyph if current one isn't.
-  if (urgencyLevel < 3 && hasType('GLYPH')) {
-    const glyphs = handByType('GLYPH');
+  // v27: dropped the `urgencyLevel < 3` gate. The persistent slot
+  // is too valuable to leave starved, even in kill mode — passive
+  // damage glyphs (Creeping Malice) accelerate kills, defensive
+  // glyphs (Aegis) buy survival time. Also added school-sort so a
+  // Black weaver prefers Black glyphs when multiple are in hand.
+  if (hasType('GLYPH')) {
+    const aiSchool = pub.players?.ai?.weaver?.school;
+    const glyphs = handByType('GLYPH').slice().sort((a, b) => {
+      const aMatch = a.school === aiSchool ? 1 : 0;
+      const bMatch = b.school === aiSchool ? 1 : 0;
+      if (aMatch !== bMatch) return bMatch - aMatch;       // school-matching first
+      const aDmg = dealsDamage(a) || /damage/i.test(a.text || '') ? 1 : 0;
+      const bDmg = dealsDamage(b) || /damage/i.test(b.text || '') ? 1 : 0;
+      return killMode ? bDmg - aDmg : aDmg - bDmg;          // kill mode prefers damage; otherwise prefer non-damage utility
+    });
     const dmgGlyph = glyphs.find(g => dealsDamage(g) || /damage/i.test(g.text || ''));
     const open = glyphSlotOpen();
     if (open) {
-      api.setGlyphFromHand(side, (dmgGlyph || glyphs[0]).id);
+      api.setGlyphFromHand(side, glyphs[0].id);
       return state;
     }
-    // Replace: only when in kill mode and swapping to a damage glyph upgrades us
+    // Replace: only in kill mode and only if swapping to a damage glyph upgrades us.
     if (killMode && dmgGlyph && !currentGlyphIsDmg()) {
       try { api.setGlyphFromHand(side, dmgGlyph.id); return state; } catch { /* ignore */ }
     }

--- a/index.html
+++ b/index.html
@@ -5,7 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <title>The Grey — board</title>
   <link href="https://fonts.googleapis.com/css2?family=Cormorant+Garamond:wght@400;600&family=Crimson+Text:wght@600&display=swap" rel="stylesheet">
-  <link rel="stylesheet" href="./styles.css?v=mlv26-20260509" />
+  <link rel="stylesheet" href="./styles.css?v=mlv27-20260509" />
 </head>
 <body id="board" class="theme-dark parchment">
 
@@ -164,7 +164,7 @@
     </div>
   </div>
 
-  <script type="module" src="./index.js?v=mlv26-20260509"></script>
+  <script type="module" src="./index.js?v=mlv27-20260509"></script>
 </body>
 
 </html>

--- a/index.js
+++ b/index.js
@@ -565,6 +565,16 @@ function animateDamage(side, amount = 1) {
   setTimeout(() => host.classList.remove('hit'), 320);
   setTimeout(() => host.classList.remove('hit-shake'), 360);
 
+  // v27 — rail-wide red flash. v20 moved HP to the small rail host
+  // so the inner-element flash got tiny and easy to miss. Pulse the
+  // entire rail (full board width) so damage registers viscerally.
+  const rail = document.querySelector(side === 'player' ? '.wincon-rail.wc-player' : '.wincon-rail.wc-ai');
+  if (rail) {
+    rail.classList.add('rail-hit');
+    setTimeout(() => rail.classList.remove('rail-hit'), 360);
+  }
+  try { navigator.vibrate?.(80); } catch {}
+
   // floating “-N” centered above the hearts
   const floater = document.createElement('div');
   floater.className = 'damage-float red';
@@ -613,6 +623,30 @@ function animateDamage(side, amount = 1) {
   }
 }
 
+
+// v27 — heal floater + rail flash. Mirrors animateDamage's lifecycle
+// in green. Triggered by the engine's `heal` events from Mercy of the
+// Flow, Sanctifying Light, Aether Shield. Without this, White school
+// heals were happening silently.
+function animateHeal(side, amount = 1) {
+  const host = heartsHost(side) || document.body;
+  if (!host) return;
+  host.classList.add('healed');
+  setTimeout(() => host.classList.remove('healed'), 360);
+  const rail = document.querySelector(side === 'player' ? '.wincon-rail.wc-player' : '.wincon-rail.wc-ai');
+  if (rail) {
+    rail.classList.add('rail-heal');
+    setTimeout(() => rail.classList.remove('rail-heal'), 480);
+  }
+  // Floating "+N" centered above the rail HP host.
+  const anchor = heartsElFor(side) || host;
+  const floater = document.createElement('div');
+  floater.className = 'heal-float green';
+  floater.textContent = `+${amount|0 || 1}`;
+  anchor.appendChild(floater);
+  floater.addEventListener('animationend', () => floater.remove(), { once:true });
+  try { navigator.vibrate?.([8, 30]); } catch {}
+}
 
 // v16: +X Æ floater — mirrors animateDamage's lifecycle but rises
 // from the chip's aether display in blue. Triggered on
@@ -2151,6 +2185,14 @@ function renderWinconRail(side) {
 // v21: append/update a rail token badge (Ward count, Free Buy count).
 // Idempotent: first call creates the badge, subsequent calls just update
 // the number and visibility. Hidden when count is 0.
+// v27: tooltip strings so the unicode glyphs ⛨ / ◇+ aren't opaque on
+// first sight. Desktop hover shows the title; iOS long-press exposes
+// it via the native context menu; aria-label is consumed by screen
+// readers for accessibility.
+const RAIL_BADGE_TITLES = {
+  ward: 'Ward — absorbs the next damage instance you would take',
+  'free-buy': 'Free Buy — lets you bypass the once-per-turn buy cap',
+};
 function paintRailBadge(hostId, kind, count, glyph) {
   const host = document.getElementById(hostId);
   if (!host) return;
@@ -2159,6 +2201,11 @@ function paintRailBadge(hostId, kind, count, glyph) {
     badge = document.createElement('span');
     badge.className = `wcr-badge b-${kind}`;
     badge.innerHTML = `<span class="b-ico" aria-hidden="true">${glyph}</span><span class="b-n">0</span>`;
+    const title = RAIL_BADGE_TITLES[kind] || '';
+    if (title) {
+      badge.title = title;
+      badge.setAttribute('aria-label', title);
+    }
     host.appendChild(badge);
   }
   badge.classList.toggle('hidden', !count);
@@ -4241,23 +4288,38 @@ function ensureOutcomeOverlay() {
 }
 
 function showOutcome(type, condition) { // type: "win"|"lose", condition: "ruin"|"confluence"|"dominion"
-  const o = ensureOutcomeOverlay();
-  const title = o.querySelector("#outcome-title");
-  title.className = "";
-  title.classList.add(type);
-  title.textContent = type === "win" ? "YOU WIN" : "YOU LOSE";
+  // v27 — fanfare: a 600ms full-screen flash (gold for victory, red
+  // for defeat) precedes the modal so the win/loss has weight rather
+  // than just popping a modal in the player's face.
+  const flashClass = type === 'win' ? 'outcome-flash-victory' : 'outcome-flash-defeat';
+  document.body.classList.add(flashClass);
+  setTimeout(() => document.body.classList.remove(flashClass), 600);
 
-  const flavour = {
-    ruin:        type === "win" ? "by Annihilation"          : "Annihilated",
-    confluence:  type === "win" ? "by Aetherflow Dominance"  : "Aetherflow Claimed",
-    dominion:    type === "win" ? "by Grey Mastery"           : "Grey Mastered",
+  const renderModal = () => {
+    const o = ensureOutcomeOverlay();
+    const title = o.querySelector("#outcome-title");
+    title.className = "";
+    title.classList.add(type);
+    title.textContent = type === "win" ? "YOU WIN" : "YOU LOSE";
+
+    const flavour = {
+      ruin:        type === "win" ? "by Annihilation"          : "Annihilated",
+      confluence:  type === "win" ? "by Aetherflow Dominance"  : "Aetherflow Claimed",
+      dominion:    type === "win" ? "by Grey Mastery"           : "Grey Mastered",
+    };
+    const sub = o.querySelector("#outcome-sub");
+    if (sub) sub.textContent = flavour[condition] || "Tap Retry to start a fresh duel.";
+    o.classList.add("open");
   };
-  const sub = o.querySelector("#outcome-sub");
-  if (sub) sub.textContent = flavour[condition] || "Tap Retry to start a fresh duel.";
-  o.classList.add("open");
+  // Delay the modal so the flash registers before the dialog steals focus.
+  setTimeout(renderModal, 400);
 }
 
 
+// v27 — pending-win banner is now sticky (not auto-hidden after 5s)
+// and triggers a single screen-flash on the transition into the
+// pending state. Auto-clears when a fresh, non-pending render lands.
+let _pendingWinShown = false;
 function showPendingWinBanner(side, condition) {
   let banner = document.getElementById("pending-win-banner");
   if (!banner) {
@@ -4269,7 +4331,21 @@ function showPendingWinBanner(side, condition) {
   const cLabel = condition === 'confluence' ? "Aetherflow Dominance" : "Grey Mastery";
   banner.textContent = `⚠ ${who} will claim ${cLabel} — final turn!`;
   banner.classList.add("show");
-  setTimeout(() => banner.classList.remove("show"), 5000);
+  banner.classList.toggle('threat-from-ai', side !== 'player');
+  // Trigger screen flash only on transitions INTO pending-win, not on
+  // every render call while the banner is up.
+  if (!_pendingWinShown) {
+    _pendingWinShown = true;
+    document.body.classList.add('pending-win-flash');
+    setTimeout(() => document.body.classList.remove('pending-win-flash'), 700);
+  }
+  // Sticky: keep visible until clearPendingWinBanner runs (called from
+  // render when state.pendingWin clears — see below).
+}
+function clearPendingWinBanner() {
+  const banner = document.getElementById("pending-win-banner");
+  if (banner) banner.classList.remove("show");
+  _pendingWinShown = false;
 }
 
 // v20: renderWinTracks deleted. The chip-mounted Confluence/Dominion
@@ -4663,14 +4739,39 @@ async function spotlightFromEvents(state){
           state.reactionWindow = { side, trigger: trig, defender: (side === 'player' ? 0 : 1) };
         }
         if (side === 'ai') {
-          // AI reaction: pick first affordable reaction card and cast it automatically
+          // v27 — AI reaction picker. Was: cast the FIRST affordable reaction
+          // regardless of trigger. Mercy of the Flow's effect handler checks
+          // `trigger === 'damage'`, so a Mercy played on a `spell_cast`
+          // trigger silently no-ops. Now we filter by trigger compatibility
+          // and prioritize within the matching set.
           const hand = state.players?.ai?.hand || [];
-          const reactionCards = hand.filter(c => c.type === 'REACTION' && ((c.playCost ?? c.cost ?? 0) <= getTotal('ai')));
-          if (reactionCards.length > 0) {
-            const card = reactionCards[0];
-            state = await window.castInstantFromHand(state, 'ai', card.id);
+          const aff  = (c) => ((c.playCost ?? c.cost ?? 0) <= getTotal('ai'));
+          const txt  = (c) => String(c?.text || '').toLowerCase();
+          // Trigger-text compatibility:
+          //   damage trigger     → cards mentioning "deals damage" / "take damage"
+          //   spell_cast trigger → cards mentioning "plays a spell"
+          //   spell_advance trig → cards mentioning "advance"
+          const compatibleFor = (c) => {
+            const t = txt(c);
+            if (trig === 'damage')        return /deals\s+damage|take\s+damage|opponent\s+deals/.test(t);
+            if (trig === 'spell_cast')    return /plays?\s+a\s+spell/.test(t);
+            if (trig === 'spell_advance') return /advance/.test(t);
+            return false;
+          };
+          const reactions = hand
+            .filter(c => c.type === 'REACTION' && aff(c) && compatibleFor(c));
+          // Priority: cheaper first (saves Æ for own turn), then by name to
+          // be deterministic across turns. Future: rank by expected value.
+          reactions.sort((a, b) => {
+            const ca = a.playCost ?? a.cost ?? 0;
+            const cb = b.playCost ?? b.cost ?? 0;
+            return ca - cb || String(a.name||'').localeCompare(String(b.name||''));
+          });
+          if (reactions.length > 0) {
+            const card = reactions[0];
+            try { state = await window.castInstantFromHand(state, 'ai', card.id); } catch {}
           }
-          // After AI reacts (or if it cannot), close the reaction window and continue
+          // After AI reacts (or if no compatible card), close the window.
           state.reactionWindow = null;
           closeReactionWindow(true);
         } else if (side === 'player') {
@@ -4887,6 +4988,40 @@ async function spotlightFromEvents(state){
         }
         animateDamage(e.side, e.amount || 1);
         markNewestLostHeartShattered(e.side);
+      }
+
+      // v27 — Heal feedback. Mercy of the Flow + Sanctifying Light +
+      // Aether Shield were healing silently; the engine pushes a
+      // `heal` event but no consumer existed.
+      if (e.t === 'heal' && (e.amount | 0) > 0) {
+        animateHeal(e.side, e.amount | 0);
+      }
+
+      // v27 — Aether-gain pulse. Brief blue glow on the chip's aether
+      // gem when the side gains aether (positive amounts only — paying
+      // a cost emits negative `amount` and we don't want a fake gain).
+      // Skipped during reaction windows to avoid stacking with the
+      // existing animateAetherGain for explicit gains.
+      if (e.t === 'aether' && (e.amount | 0) > 0) {
+        const aeEl = document.getElementById(e.side === 'player' ? 'player-aether' : 'ai-aether');
+        if (aeEl) {
+          aeEl.classList.add('aether-pulse');
+          setTimeout(() => aeEl.classList.remove('aether-pulse'), 520);
+        }
+      }
+
+      // v27 — AI play narration. The Grey event bus already wires
+      // CARD_PLAYED/CARD_SET/CARD_CAST/BUY toasts, but spell-RESOLVE
+      // (when an AI spell finishes its pip count and discharges) and
+      // REACTION resolutions weren't toasted. Add them here so the
+      // player sees every meaningful AI moment, not just plays.
+      if (e.t === 'resolved' && e.side === 'ai') {
+        const cardName = e.cardData?.name || 'a card';
+        if (e.source === 'spell') {
+          aiActionToast(`Opponent resolves ${cardName}`);
+        } else if (e.source === 'reaction') {
+          aiActionToast(`Opponent reacts with ${cardName}`);
+        }
       }
 
       // Reshuffle VFX (discard → deck)
@@ -5530,11 +5665,14 @@ function triggerTranceUnlockMoment(side, lvl){
     `<div class="tt-tier">${sideLabel} · TRANCE ${lvl === 2 ? 'II' : 'I'}</div>` +
     `<div class="tt-name">${tierName}</div>` +
     `<div class="tt-desc">${tierDesc}</div>`;
-  _tranceToastEl.classList.add('show');
+  // v27: top-banner placement (was centered/modal-feeling) + shorter
+  // duration so a clutch trance unlock during the opponent's lethal
+  // turn doesn't cover the play area while damage is incoming.
+  _tranceToastEl.classList.add('show', 'top-banner');
   clearTimeout(_tranceToastTimer);
   _tranceToastTimer = setTimeout(() => {
     _tranceToastEl?.classList.remove('show');
-  }, 2200);
+  }, 1400);
 
   logLine(`✦ ${side} entered TRANCE ${lvl} — ${tierName}`);
 }
@@ -5579,11 +5717,49 @@ function triggerHexAppliedMoment(side, slotIndex){
 }
 
 
+// v27 — turn-transition toast. Diffed against the previous render's
+// activePlayer; on a flip we briefly show a centered banner so the
+// player sees who's acting now. Mobile portrait especially needed
+// this — without a transition signal you can't tell whose turn it
+// is unless you're watching the hand-disabled state.
+let _lastActivePlayer = null;
+function showTurnToast(side) {
+  let el = document.getElementById('turn-toast');
+  if (!el) {
+    el = document.createElement('div');
+    el.id = 'turn-toast';
+    document.body.appendChild(el);
+  }
+  el.textContent = side === 'player' ? 'Your Turn' : "Opponent's Turn";
+  el.classList.toggle('player', side === 'player');
+  el.classList.toggle('ai', side === 'ai');
+  el.classList.remove('show');
+  // force reflow so the next class add re-runs the transition
+  void el.offsetWidth;
+  el.classList.add('show');
+  clearTimeout(showTurnToast._t);
+  showTurnToast._t = setTimeout(() => el.classList.remove('show'), 700);
+}
+
 async function render(){
   const s = ensureSafetyShape(serializePublic(state) || {});
 
   // Mirror active side onto body so CSS can show/hide slot rows etc.
   document.body.dataset.activeSide = (s.activePlayer === 'ai') ? 'ai' : 'player';
+
+  // v27: announce turn transitions. Skip the very first paint so we
+  // don't toast "Your Turn" before the welcome overlay closes.
+  if (_lastActivePlayer !== null && s.activePlayer !== _lastActivePlayer) {
+    showTurnToast(s.activePlayer);
+  }
+  _lastActivePlayer = s.activePlayer;
+
+  // v27: keep the pending-win banner sticky while a threat is live;
+  // clear it when state.pendingWin transitions away (threat denied,
+  // game ended, etc.).
+  if (!state?.pendingWin && _pendingWinShown) {
+    clearPendingWinBanner();
+  }
 
   // Wire pip click handlers once, after #player-slots exists
   if (!pipUIWired) {

--- a/styles.css
+++ b/styles.css
@@ -3135,3 +3135,164 @@ body.mobile-landscape #peek-card.card.peek {
   box-shadow: inset 0 0 0 3px rgba(124, 136, 152, .80);
   border-color: rgba(124, 136, 152, .80);
 }
+
+
+/* ==========================================================
+   v27: feedback signaling + polish
+   - Heal floater + rail flash (mirror of damage-float in green)
+   - Aether-gain gem pulse
+   - Turn-transition toast (#turn-toast)
+   - Rail-wide damage hit flash (M5)
+   - Pending-win screen flash + sticky banner styling (M6)
+   - Trance toast top-banner placement (M7)
+   - Win/Lose fanfare flash (m2)
+   ========================================================== */
+
+/* Heal floater — mirrors .damage-float layout with a green palette. */
+.heal-float {
+  position: absolute;
+  left: 50%;
+  top: 8px;
+  transform: translateX(-50%) translateY(0) scale(.9);
+  font-weight: 800;
+  font-size: 20px;
+  pointer-events: none;
+  opacity: 0;
+  animation: heal-pop 900ms ease-out forwards;
+}
+.heal-float.green {
+  color: #6fe07a;
+  text-shadow: 0 0 10px rgba(80, 220, 110, .65);
+}
+@keyframes heal-pop {
+  0%   { opacity: 0; transform: translateX(-50%) translateY(6px)  scale(.8); }
+  14%  { opacity: 1; transform: translateX(-50%) translateY(-10px) scale(1.15); }
+  70%  { opacity: 1; transform: translateX(-50%) translateY(-26px) scale(1.0); }
+  100% { opacity: 0; transform: translateX(-50%) translateY(-44px) scale(1.0); }
+}
+
+/* Rail-wide flash on damage. Was: only the small HP host flashed,
+   which was easy to miss now that HP lives on the slim rail. */
+.wincon-rail.rail-hit {
+  animation: rail-hit-flash .36s ease-out;
+}
+@keyframes rail-hit-flash {
+  0%   { background: rgba(180, 50, 50, .55); box-shadow: 0 0 0 2px rgba(255,80,80,.6) inset; }
+  60%  { background: rgba(120, 30, 30, .25); box-shadow: 0 0 0 1px rgba(255,80,80,.3) inset; }
+  100% { background: inherit; box-shadow: none; }
+}
+
+/* Rail-wide green pulse on heal — subtler than damage so it doesn't
+   feel like an alarm. */
+.wincon-rail.rail-heal {
+  animation: rail-heal-flash .48s ease-out;
+}
+@keyframes rail-heal-flash {
+  0%   { background: rgba(70, 170, 90, .35); }
+  60%  { background: rgba(60, 140, 80, .15); }
+  100% { background: inherit; }
+}
+
+/* Healed flash on the chip (mirrors the existing .hit pattern). */
+.healed {
+  filter: brightness(1.18) drop-shadow(0 0 12px rgba(120,255,140,.55));
+  transition: filter .14s ease;
+}
+
+/* Aether-gem pulse on positive gain. Transparent border ring expands
+   briefly so the player feels every Æ tick. */
+.aether-display.aether-pulse {
+  animation: aether-pulse .52s ease-out;
+}
+@keyframes aether-pulse {
+  0%   { box-shadow: 0 0 0 0 rgba(126,182,255,.55); }
+  60%  { box-shadow: 0 0 0 6px rgba(126,182,255,.10); }
+  100% { box-shadow: 0 0 0 0 rgba(126,182,255,0); }
+}
+
+/* Turn-transition toast. Centered horizontally, sits high above the
+   board (top of viewport) so it doesn't compete with hand cards or
+   the wincon explainer dialog. */
+#turn-toast {
+  position: fixed;
+  left: 50%; top: 22%;
+  transform: translate(-50%, -8px);
+  background: linear-gradient(180deg, rgba(40,30,18,.92), rgba(20,16,10,.92));
+  border: 1px solid #6a5840;
+  border-radius: 12px;
+  padding: 10px 22px;
+  color: #f1e3bf;
+  font-size: 1rem;
+  font-weight: 700;
+  letter-spacing: .14em;
+  text-transform: uppercase;
+  box-shadow: 0 12px 28px rgba(0,0,0,.6);
+  z-index: 5800;
+  pointer-events: none;
+  opacity: 0;
+  transition: opacity .18s ease, transform .18s ease;
+}
+#turn-toast.show {
+  opacity: 1;
+  transform: translate(-50%, 0);
+}
+#turn-toast.player { border-color: #c6a56a; color: #ffe6a8; }
+#turn-toast.ai     { border-color: #d97a7a; color: #ffb8b8; }
+body.mobile-portrait #turn-toast,
+body.mobile-landscape #turn-toast {
+  font-size: .8rem;
+  padding: 7px 14px;
+  top: 18%;
+}
+
+/* Pending-win screen flash. One-shot when the threat first appears
+   so the player can't miss the warning. */
+body.pending-win-flash {
+  animation: pending-win-flash .72s ease-out;
+}
+@keyframes pending-win-flash {
+  0%   { background: rgba(180, 30, 30, .35); }
+  100% { background: inherit; }
+}
+/* Sticky banner styling — stronger than the v17 default so it doesn't
+   blend into the board chrome. Breathes while visible. */
+#pending-win-banner.show {
+  border: 2px solid #d04040;
+  font-weight: 800;
+  letter-spacing: .04em;
+  animation: pending-banner-breathe 1.6s ease-in-out infinite;
+}
+@keyframes pending-banner-breathe {
+  0%, 100% { box-shadow: 0 0 0 2px rgba(208,64,64,.25), 0 8px 22px rgba(0,0,0,.55); }
+  50%      { box-shadow: 0 0 0 6px rgba(208,64,64,.12), 0 10px 26px rgba(0,0,0,.55); }
+}
+
+/* Trance toast top-banner placement (was centered modal-feel). The
+   default centered styling at line 2596 stays for desktop hover, but
+   v27 toggles `.top-banner` to override placement. */
+#trance-toast.top-banner {
+  top: 12% !important;
+  transform: translate(-50%, 0) scale(.96);
+}
+#trance-toast.top-banner.show {
+  transform: translate(-50%, 0) scale(1);
+}
+
+/* Win / Lose fanfare flash (m2). Brief full-screen colour wash before
+   the outcome modal appears so wins/losses have weight. */
+body.outcome-flash-victory {
+  animation: outcome-victory-flash .6s ease-out;
+}
+body.outcome-flash-defeat {
+  animation: outcome-defeat-flash .6s ease-out;
+}
+@keyframes outcome-victory-flash {
+  0%   { background: rgba(255, 220, 120, .85); }
+  60%  { background: rgba(255, 220, 120, .25); }
+  100% { background: inherit; }
+}
+@keyframes outcome-defeat-flash {
+  0%   { background: rgba(180, 30, 30, .85); }
+  60%  { background: rgba(180, 30, 30, .25); }
+  100% { background: inherit; }
+}


### PR DESCRIPTION
User: *"There's still a lot of UI UX and gameplay issues."*

Second-pass playtest audit (after v26 closed defect-class issues) found a fresh list focused on: **AI capability gaps**, **feedback signaling gaps**, and **polish issues**. User picked **Full sweep** — 2 BLOCKERs + 7 MAJORs + 2 MINORs. v27 ships them as a cohesive pass on how matches FEEL.

## AI capability

**B1 — AI reaction picker.** The previous picker took the FIRST affordable REACTION card without trigger-matching, so Mercy of the Flow could fire on a `spell_cast` trigger and silently no-op (its handler checks `trigger === 'damage'`). Now filters by trigger compatibility:
- `damage` → cards mentioning "deals damage" / "take damage" / "opponent deals" (Mercy, Aether Shield)
- `spell_cast` → cards mentioning "plays a spell" (Hexing Wisp, Spite Wisp)
- `spell_advance` → "advance" cards (Aether Disruption)

Within the matching set, picks the cheapest first.

**B2 — AI sets glyphs aggressively.** Dropped the `urgencyLevel < 3` gate; the persistent glyph slot is too valuable to leave starved even in kill mode. Added school-sort: Morr (Black) prefers Black glyphs (Creeping Malice) over White ones (Aegis) when both are in hand.

## Feedback signaling

| Issue | Fix |
|---|---|
| **M1 Heal feedback** | New `animateHeal()` mirrors `animateDamage` in green: `+N` floater, rail-wide green flash, chip brightness pulse, light haptic. Hooked into the engine event consumer's new `e.t === 'heal'` arm. White school heals finally register. |
| **M2 Aether pulse** | Aether display pulses on positive aether events (channel, trance, free-buy). Negative amounts (paying cost) skipped. |
| **M3 Turn-transition toast** | New `#turn-toast` ("Your Turn" / "Opponent's Turn") for 700ms when `activePlayer` flips. Diffed in `render()` via `_lastActivePlayer`. |
| **M4 AI play narration** | Grey event bus already toasted plays/sets/casts/buys; added spell-RESOLVE and REACTION-resolution narration so the player sees every meaningful AI moment. |
| **M5 Rail-wide damage flash** | v20's small rail HP host meant `animateDamage`'s host flash got lost. Now the entire `.wincon-rail` flashes red full-width on damage; vibrate bumped 60→80ms. |
| **M6 Pending-win sticky + flash** | 5s auto-hide replaced with sticky-while-pending; clears in `render()` when `state.pendingWin` transitions away. Single screen-flash on the transition INTO pending-win. Banner uses 2px red border + breathing animation. |
| **M7 Trance toast top-banner** | Was centered/modal-feeling, could cover the play area at clutch moments. Now anchored to top of viewport (12% from top) and shorter (2200→1400ms). |

## Polish

**m1 — Badge tooltips.** `paintRailBadge` sets `title` + `aria-label` on Ward (`⛨`) and Free-Buy (`◇+`) badges. Desktop hover shows tip; iOS long-press exposes via native context menu; screen readers get aria-label.

**m2 — Win/Lose fanfare.** `showOutcome` fires a 600ms full-screen colour flash (gold for victory, red for defeat) then delays the modal 400ms so the flash registers before the dialog steals focus.

## Files

| File | Changes |
|---|---|
| `index.js` ~4665 | B1 AI reaction picker (trigger-match + cost-priority) |
| `ai.js` ~116 | B2 dropped urgency gate + school-sort |
| `index.js` ~558 | M5 rail-wide hit flash inside `animateDamage` |
| `index.js` (new) | M1 `animateHeal()` |
| `index.js` ~4870 | Heal/aether/narration consumers in engine event loop |
| `index.js` ~5675 | M3 turn-transition toast (diff + helper) |
| `index.js` ~4308 | M6 sticky pending-win + screen flash + clear function |
| `index.js` ~5658 | M7 trance toast top-banner + 1400ms duration |
| `index.js` ~2188 | m1 badge titles |
| `index.js` ~4290 | m2 outcome flash + delayed modal |
| `styles.css` (append) | All new keyframes + classes |
| `index.html` | Cache-bust `mlv27-20260509` |

Single squashable commit `56dd8a7`.

---
_Generated by [Claude Code](https://claude.ai/code/session_01C1TYVtozydzcqvzpY15HMA)_