### PR TITLE
v31: school borders truly distinct + HUD off the AI chip

### DIFF
--- a/index.html
+++ b/index.html
@@ -5,7 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <title>The Grey — board</title>
   <link href="https://fonts.googleapis.com/css2?family=Cormorant+Garamond:wght@400;600&family=Crimson+Text:wght@600&display=swap" rel="stylesheet">
-  <link rel="stylesheet" href="./styles.css?v=mlv30-20260509" />
+  <link rel="stylesheet" href="./styles.css?v=mlv31-20260509" />
 </head>
 <body id="board" class="theme-dark parchment">
 
@@ -164,7 +164,7 @@
     </div>
   </div>
 
-  <script type="module" src="./index.js?v=mlv30-20260509"></script>
+  <script type="module" src="./index.js?v=mlv31-20260509"></script>
 </body>
 
 </html>

--- a/index.js
+++ b/index.js
@@ -4523,29 +4523,26 @@ function ensureRightHudStrip() {
     document.body.appendChild(strip);
   }
 
-  // v23: layout responds to mobile-portrait. v22 added CSS rules for a
-  // top-right horizontal cluster, but this function had been pinning
-  // the strip at bottom-right with inline styles, overriding them.
-  // v26: read the viewport DIRECTLY rather than trusting body.mobile-
-  // portrait. The orientation handler that sets that class runs as an
-  // IIFE alongside DOMContentLoaded; on first paint there was a race
-  // where this could run before the class was set, so the strip would
-  // briefly appear bottom-right before render() relocated it. Reading
-  // window dimensions matches the orientation IIFE's own logic
-  // (w<=720 && h>w) so the first paint already lands top-right.
+  // v23: layout responds to mobile-portrait. v31: top-right placement
+  // overlapped the AI portrait + name on portrait. The corner is too
+  // contested (chip name + portrait + cost badges all live there).
+  // Now the strip sits ABOVE the hand band on portrait (right edge,
+  // floating between the player slot row and the hand) — ergonomic
+  // for thumb reach and clear of any board element.
   const isPortrait = (() => {
     const w = window.innerWidth, h = window.innerHeight;
     return w <= 720 && h > w;
   })();
   Object.assign(strip.style, isPortrait ? {
     position: 'fixed',
-    top: '6px',
-    right: '6px',
-    bottom: 'auto',
+    top: 'auto',
+    right: '8px',
+    // sits just above the hand band; the band itself is var(--hand-band-h)
+    bottom: 'calc(var(--hand-band-h, 120px) + 6px)',
     left: 'auto',
     display: 'flex',
-    flexDirection: 'row',
-    gap: '6px',
+    flexDirection: 'column',
+    gap: '4px',
     zIndex: '1200',
   } : {
     position: 'fixed',

--- a/styles.css
+++ b/styles.css
@@ -2984,30 +2984,30 @@ body.mobile-landscape .wincon-rail .hp-bar-host .hp-num {
    colour all the way around the card. Stacks BEFORE the existing
    drop-shadow (0 14px 24px #000) so elevation is preserved.
    Border-color also bumps to match for the outermost 1px line. */
-/* v25/v30: school identity = inset coloured border. v30 boosted alpha
-   to 1.0 + added a 1px inner cream-coloured stroke between the card
-   body and the school colour so the three schools read distinctly
-   even on a dark card background where they were blending. */
+/* v31: school identity = bold inset coloured border, no inner stroke.
+   v30 had a 1px cream/silver inner-highlight stroke between the
+   school colour and the card body — at small portrait card size that
+   1px highlight was the only visible border, making all three schools
+   look identical (pale cream). v31 drops the highlight, bumps the
+   ring to 5px, and uses brighter saturated colours so Black reads
+   as RED, White as GOLD, Grey as STEEL BLUE at any size. */
 .card:has(.school-stripe.school-black) {
   box-shadow:
-    inset 0 0 0 1px rgba(255,210,210,.35),
-    inset 0 0 0 4px #c8302a,
+    inset 0 0 0 5px #e04545,
     0 14px 24px #000 !important;
-  border-color: #c8302a !important;
+  border-color: #e04545 !important;
 }
 .card:has(.school-stripe.school-white) {
   box-shadow:
-    inset 0 0 0 1px rgba(255,250,235,.55),
-    inset 0 0 0 4px #f0d97a,
+    inset 0 0 0 5px #f5e08c,
     0 14px 24px #000 !important;
-  border-color: #f0d97a !important;
+  border-color: #f5e08c !important;
 }
 .card:has(.school-stripe.school-grey) {
   box-shadow:
-    inset 0 0 0 1px rgba(220,228,240,.30),
-    inset 0 0 0 4px #8da4c0,
+    inset 0 0 0 5px #a8b8d0,
     0 14px 24px #000 !important;
-  border-color: #8da4c0 !important;
+  border-color: #a8b8d0 !important;
 }
 
 /* v28: when a card is INSIDE a .slot, mute its own school ring —
@@ -3198,25 +3198,18 @@ body.mobile-landscape #peek-card.card.peek {
    ring on the slot itself once a card lands).
    ========================================================== */
 
-/* v30: slot ring matches v30 card colours so school identity is
-   consistent inside slots and in hand. */
+/* v31: slot ring matches the v31 card colours (bright + 5px solid). */
 .slot[data-school="black"] {
-  box-shadow:
-    inset 0 0 0 1px rgba(255,210,210,.35),
-    inset 0 0 0 4px #c8302a;
-  border-color: #c8302a;
+  box-shadow: inset 0 0 0 5px #e04545;
+  border-color: #e04545;
 }
 .slot[data-school="white"] {
-  box-shadow:
-    inset 0 0 0 1px rgba(255,250,235,.55),
-    inset 0 0 0 4px #f0d97a;
-  border-color: #f0d97a;
+  box-shadow: inset 0 0 0 5px #f5e08c;
+  border-color: #f5e08c;
 }
 .slot[data-school="grey"] {
-  box-shadow:
-    inset 0 0 0 1px rgba(220,228,240,.30),
-    inset 0 0 0 4px #8da4c0;
-  border-color: #8da4c0;
+  box-shadow: inset 0 0 0 5px #a8b8d0;
+  border-color: #a8b8d0;
 }
 
 


### PR DESCRIPTION
User screenshot of v30 surfaced two issues that v30 had attempted to fix but didn't:

## 1. School borders STILL looked the same

v30 used a `box-shadow: inset 0 0 0 1px <cream/silver>, inset 0 0 0 4px <school-color>` stack. The 1px highlight stroke sat on TOP of the school colour at the very edge of the card. On small portrait cards (60px market cards) the **only visible edge was that 1px cream highlight** — the saturated school colour underneath was drowned out, and all three schools read as identical pale-cream borders.

**v31 fix:** drop the highlight stroke entirely. Use a single 5px solid school-coloured ring with brighter saturated hex values:

| | v30 | v31 |
|---|---|---|
| Black | `#c8302a` (4px + 1px highlight) | `#e04545` (5px solid) |
| White | `#f0d97a` (4px + 1px highlight) | `#f5e08c` (5px solid) |
| Grey | `#8da4c0` (4px + 1px highlight) | `#a8b8d0` (5px solid) |

Black now reads as RED, White as GOLD, Grey as STEEL BLUE at any card size. Mirrored on `.slot[data-school]` rules so placed cards stay consistent.

## 2. HUD overlapped Morr's chip

v30 shrunk the top-right buttons but kept them positioned at `top:6px right:6px` — the SAME corner as the AI chip (portrait + name + `BLACK` school badge). v30 made the contested corner less aggressive but didn't resolve the overlap.

**v31 fix:** on mobile portrait, the strip relocates to **bottom-right above the hand band**. Vertical stack at `right:8px / bottom:calc(var(--hand-band-h) + 6px)`, 4px gap. End Turn sits closest to the thumb. The top-right corner is now empty for Morr's chip to breathe.

Desktop / landscape layout unchanged.

## Files

| File | Change |
|---|---|
| `index.js` (`ensureRightHudStrip`) | Mobile-portrait inline styles changed from `top:6px right:6px` row layout → `bottom:hand-band+6px right:8px` column layout |
| `styles.css` (`.card:has(.school-stripe.school-X)`) | Removed 1px highlight stroke; 4px → 5px school ring; brighter hex |
| `styles.css` (`.slot[data-school="X"]`) | Same colour bump |
| `index.html` | Cache-bust `mlv31-20260509` |

Single squashable commit `db0d70a`.

---
_Generated by [Claude Code](https://claude.ai/code/session_01C1TYVtozydzcqvzpY15HMA)_