### PR TITLE
v32: borders bolder + popup vertical + End Turn unmistakable

### DIFF
--- a/index.html
+++ b/index.html
@@ -5,7 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <title>The Grey — board</title>
   <link href="https://fonts.googleapis.com/css2?family=Cormorant+Garamond:wght@400;600&family=Crimson+Text:wght@600&display=swap" rel="stylesheet">
-  <link rel="stylesheet" href="./styles.css?v=mlv31-20260509" />
+  <link rel="stylesheet" href="./styles.css?v=mlv32-20260509" />
 </head>
 <body id="board" class="theme-dark parchment">
 
@@ -164,7 +164,7 @@
     </div>
   </div>
 
-  <script type="module" src="./index.js?v=mlv31-20260509"></script>
+  <script type="module" src="./index.js?v=mlv32-20260509"></script>
 </body>
 
 </html>

--- a/index.js
+++ b/index.js
@@ -4563,7 +4563,10 @@ function ensureRightHudStrip() {
     if (!n) return;
 
     // Hard-reset legacy positioning so the strip's flex layout controls it.
-    // End Turn stays slightly larger as the most-tapped action.
+    // v32: End Turn substantially bigger on portrait (52×44 vs 32×32 for
+    // deck/discard) so the most-tapped action is easy to find. The size
+    // gap also makes it impossible to confuse with the secondary
+    // pile-viewer buttons.
     const isEndTurn = btnId === 'btn-endturn-hud';
     Object.assign(n.style, {
       position: 'static',
@@ -4572,9 +4575,11 @@ function ensureRightHudStrip() {
       transform: 'none',
       display: 'grid',
       placeItems: 'center',
-      borderRadius: isPortrait ? '10px' : '12px',
-      width:  isPortrait ? (isEndTurn ? '48px' : '36px') : '52px',
-      height: isPortrait ? '36px' : '52px',
+      borderRadius: isPortrait ? (isEndTurn ? '12px' : '8px') : '12px',
+      width:  isPortrait ? (isEndTurn ? '52px' : '32px') : '52px',
+      height: isPortrait ? (isEndTurn ? '44px' : '32px') : '52px',
+      fontSize: isPortrait ? (isEndTurn ? '20px' : '12px') : '',
+      fontWeight: isEndTurn ? '900' : '',
       pointerEvents: 'auto'
     });
 

--- a/styles.css
+++ b/styles.css
@@ -2984,30 +2984,37 @@ body.mobile-landscape .wincon-rail .hp-bar-host .hp-num {
    colour all the way around the card. Stacks BEFORE the existing
    drop-shadow (0 14px 24px #000) so elevation is preserved.
    Border-color also bumps to match for the outermost 1px line. */
-/* v31: school identity = bold inset coloured border, no inner stroke.
-   v30 had a 1px cream/silver inner-highlight stroke between the
-   school colour and the card body — at small portrait card size that
-   1px highlight was the only visible border, making all three schools
-   look identical (pale cream). v31 drops the highlight, bumps the
-   ring to 5px, and uses brighter saturated colours so Black reads
-   as RED, White as GOLD, Grey as STEEL BLUE at any size. */
+/* v32: school borders bolder again — v31's 5px solid colours still
+   read as pale on dark cards in screenshots. Bumped to a cleaner
+   2-stop palette (vibrant interior, near-black outer hairline so
+   it pops against the table) plus an outer glow that makes the
+   school identity unmistakable from across the board.
+   - Black: vivid red interior + crimson glow
+   - White: warm yellow interior + gold glow
+   - Grey:  steel blue interior + cool glow */
 .card:has(.school-stripe.school-black) {
   box-shadow:
-    inset 0 0 0 5px #e04545,
+    inset 0 0 0 5px #ff5c5c,
+    inset 0 0 0 6px #5a0a0a,
+    0 0 14px rgba(255,80,80,.5),
     0 14px 24px #000 !important;
-  border-color: #e04545 !important;
+  border-color: #ff5c5c !important;
 }
 .card:has(.school-stripe.school-white) {
   box-shadow:
-    inset 0 0 0 5px #f5e08c,
+    inset 0 0 0 5px #ffe06a,
+    inset 0 0 0 6px #5a4a10,
+    0 0 14px rgba(255,220,100,.45),
     0 14px 24px #000 !important;
-  border-color: #f5e08c !important;
+  border-color: #ffe06a !important;
 }
 .card:has(.school-stripe.school-grey) {
   box-shadow:
-    inset 0 0 0 5px #a8b8d0,
+    inset 0 0 0 5px #b0c8e8,
+    inset 0 0 0 6px #2a3850,
+    0 0 14px rgba(160,200,240,.35),
     0 14px 24px #000 !important;
-  border-color: #a8b8d0 !important;
+  border-color: #b0c8e8 !important;
 }
 
 /* v28: when a card is INSIDE a .slot, mute its own school ring —
@@ -3198,18 +3205,18 @@ body.mobile-landscape #peek-card.card.peek {
    ring on the slot itself once a card lands).
    ========================================================== */
 
-/* v31: slot ring matches the v31 card colours (bright + 5px solid). */
+/* v32: slot ring matches the bolder v32 palette. */
 .slot[data-school="black"] {
-  box-shadow: inset 0 0 0 5px #e04545;
-  border-color: #e04545;
+  box-shadow: inset 0 0 0 5px #ff5c5c, inset 0 0 0 6px #5a0a0a;
+  border-color: #ff5c5c;
 }
 .slot[data-school="white"] {
-  box-shadow: inset 0 0 0 5px #f5e08c;
-  border-color: #f5e08c;
+  box-shadow: inset 0 0 0 5px #ffe06a, inset 0 0 0 6px #5a4a10;
+  border-color: #ffe06a;
 }
 .slot[data-school="grey"] {
-  box-shadow: inset 0 0 0 5px #a8b8d0;
-  border-color: #a8b8d0;
+  box-shadow: inset 0 0 0 5px #b0c8e8, inset 0 0 0 6px #2a3850;
+  border-color: #b0c8e8;
 }
 
 
@@ -3520,49 +3527,62 @@ body.mobile-portrait .hand .card.is-focus,
   z-index: 5000 !important;
 }
 
-/* v30 — action popover slimmer. Was min(360px, 80vw) → felt huge
-   on portrait. Now 280px max so it rides above the focused card
-   without spanning over neighbours. Padding tightened. */
-body.mobile-portrait .action-pop,
+/* v32 — vertical action popover on portrait. v30 made it 280px wide
+   with side-by-side buttons, but that still spanned across Aria's
+   portrait + name when the focused card was near screen-edge. Now
+   the buttons stack vertically so the popover is narrow (max 180px)
+   and easily fits above the focused card without spreading into
+   neighbouring UI. Landscape stays horizontal where there's room. */
+body.mobile-portrait .action-pop {
+  width: min(180px, 60vw) !important;
+  flex-direction: column !important;
+  padding: 8px !important;
+  gap: 6px !important;
+}
+body.mobile-portrait .action-pop .rune-btn {
+  width: 100% !important;
+  padding: 8px 10px !important;
+  font-size: .88rem !important;
+  min-height: 38px !important;
+}
 body.mobile-landscape .action-pop {
   width: min(280px, 78vw) !important;
   padding: 8px 10px !important;
   gap: 8px !important;
 }
-body.mobile-portrait .action-pop .rune-btn,
 body.mobile-landscape .action-pop .rune-btn {
   padding: 8px 12px !important;
   font-size: .9rem !important;
   min-height: 38px !important;
 }
 
-/* v30 — HUD shrink + reposition. The 36px-square top-right buttons
-   were cutting into the rightmost flow card on portrait. Drop to
-   28px and make them low-opacity until tapped so they recede when
-   the player isn't looking for them. */
+/* v32 — HUD: ensureRightHudStrip writes inline width/height/font-size
+   so the End Turn (52×44) is clearly the primary action and deck/
+   discard (32×32) recede as secondary. CSS only handles opacity
+   feedback so deck/discard fade in on interaction. */
 body.mobile-portrait #hud-right-strip {
-  gap: 4px !important;
+  gap: 4px;
 }
-body.mobile-portrait .hud-btn {
-  width: 28px !important;
-  height: 28px !important;
-  border-radius: 8px !important;
-  font-size: 11px !important;
+body.mobile-portrait #btn-discard-hud,
+body.mobile-portrait #btn-deck-hud {
   opacity: .55;
   transition: opacity .14s ease;
 }
-body.mobile-portrait .hud-btn:hover,
-body.mobile-portrait .hud-btn:focus,
-body.mobile-portrait .hud-btn:active {
+body.mobile-portrait #btn-discard-hud:hover,
+body.mobile-portrait #btn-discard-hud:focus,
+body.mobile-portrait #btn-discard-hud:active,
+body.mobile-portrait #btn-deck-hud:hover,
+body.mobile-portrait #btn-deck-hud:focus,
+body.mobile-portrait #btn-deck-hud:active {
   opacity: 1;
 }
-/* End-Turn stays a touch larger + always-bright since it's the
-   most-tapped action. */
+/* End Turn always bright + a soft amber glow so it draws the eye. */
 body.mobile-portrait #btn-endturn-hud {
-  width: 40px !important;
-  height: 28px !important;
-  opacity: 1 !important;
-  font-size: 14px !important;
+  opacity: 1;
+  box-shadow:
+    0 0 0 1px rgba(255,224,160,.6),
+    0 4px 12px rgba(0,0,0,.6),
+    0 0 16px rgba(255,200,100,.25);
 }
 
 /* v30 — buy-cap dim toned down. v18's .42 opacity + grayscale .3


### PR DESCRIPTION
User screenshot of v31 showed three problems:
- Borders distinguishable but still **muted on dark cards under typical lighting**
- Action popover still wide enough to span across Aria's portrait when focusing a card near screen-edge
- End Turn now bottom-right but **same size as deck/discard** — no visual hierarchy, hard to find

## Fixes

### 1. School borders bolder + glow

Two inset rings stack now (vivid interior + near-black hairline outside) plus a 14px outer glow so each school carries from across the board:

| | Interior | Hairline | Glow |
|---|---|---|---|
| Black | `#ff5c5c` | `#5a0a0a` | red `rgba(255,80,80,.5)` |
| White | `#ffe06a` | `#5a4a10` | gold `rgba(255,220,100,.45)` |
| Grey | `#b0c8e8` | `#2a3850` | cool `rgba(160,200,240,.35)` |

Mirrored on `.slot[data-school]`.

### 2. Action popover vertical on portrait

Stacks Play/Channel buttons **vertically** on mobile portrait so the popover is narrow (`max-width: min(180px, 60vw)`) and fits above the focused card without spanning over the player chip. Buttons go full-width-of-popover. Landscape stays horizontal.

### 3. End Turn unmistakable

| | v31 | v32 |
|---|---|---|
| End Turn size | 28×28 | **52×44** |
| Font | default | **20px / 900** |
| Glow | none | amber outer glow + 1px gold ring |
| Deck/Discard | 28×28 | 32×32, opacity .55 idle |

End Turn is now visually dominant + always bright; deck/discard fade in only when interacted with. Removed the v30 `!important` rules that had been locking the old sizes against the new inline styles.

## Files

| File | Change |
|---|---|
| `index.js` (`ensureRightHudStrip`) | Inline width/height/font-size variants per button on portrait |
| `styles.css` (`.card:has(.school-stripe.school-X)`) | 2-ring stack + outer glow per school |
| `styles.css` (`.slot[data-school]`) | Same stack, no glow |
| `styles.css` (action-pop) | Vertical layout on portrait, narrower max-width |
| `styles.css` (HUD) | Removed v30 `!important` blockers; End Turn amber glow |
| `index.html` | Cache-bust `mlv32-20260509` |

Single squashable commit `2ff872d`.

---
_Generated by [Claude Code](https://claude.ai/code/session_01C1TYVtozydzcqvzpY15HMA)_